### PR TITLE
Call/CC & Tail Call Optimization & Primitives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ cmake_build
 cmake-build-release
 cmake-test
 result
+cmake-pg

--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ Glom basically follows the [R5RS Scheme standard](https://docs.racket-lang.org/r
   - [x] Context
   - [x] Primitive Members
   - [x] Evaluation with Immutable Context
-  - [ ] Tail Call Optimization
+  - [x] Tail Call Optimization
 - High Distinction Ideas
   - [x] int64 & bigint & rational & real(long double)
   - [ ] Evaluation with Mutable Context
+  - [x] Call with Current Context (call/cc)
   - [ ] Delayed Evaluation
   - [ ] Module
   - [ ] Standard Library

--- a/include/context.h
+++ b/include/context.h
@@ -18,7 +18,6 @@ using std::shared_ptr;
 using std::unordered_map;
 
 class Expr;
-class Param;
 
 typedef unordered_map<std::string_view, shared_ptr<Expr>> variables;
 /**
@@ -32,6 +31,7 @@ protected:
     shared_ptr<Context> parent = nullptr;
     variables bindings;
 public:
+    size_t depth;
     shared_ptr<Expr> get(const std::string_view& name) const;
     bool has(const std::string_view& name) const;
     Context& operator=(const Context&) = delete;
@@ -39,13 +39,6 @@ public:
     void set_parent(shared_ptr<Context> new_parent);
     void add(std::string_view name, shared_ptr<Expr> value);
     void add_primitive(const string& name, PrimitiveProc proc);
-
-    shared_ptr<Expr> eval(shared_ptr<Expr> expr);
-    shared_ptr<Expr> eval(const shared_ptr<Pair>& exprs);
-    shared_ptr<Expr> eval(const vector<shared_ptr<Expr>>& exprs);
-
-    shared_ptr<Context> eval_apply_context(const shared_ptr<Expr>& proc, shared_ptr<Context> current_parent,
-                                                  const vector<Param>& params, shared_ptr<Pair>&& args);
 
     string to_string() const;
 

--- a/include/eval.h
+++ b/include/eval.h
@@ -1,0 +1,36 @@
+//
+// Created by glom on 10/1/25.
+//
+
+#ifndef GLOM_EVAL_H
+#define GLOM_EVAL_H
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+using std::string;
+using std::vector;
+using std::unique_ptr;
+using std::shared_ptr;
+using std::unordered_map;
+
+class Expr;
+class Param;
+class Pair;
+class Context;
+
+
+/**
+ * Eval Model
+ * - Eval with expr in context
+ *   - The result is EvalResult = expr | Continuation
+ */
+
+shared_ptr<Expr> eval(const shared_ptr<Context>& ctx, shared_ptr<Expr> expr);
+shared_ptr<Expr> eval(const shared_ptr<Context>& ctx, shared_ptr<Pair> rest);
+
+shared_ptr<Context> eval_apply_context(const shared_ptr<Context>& ctx, const shared_ptr<Expr>& proc, const shared_ptr<Context>& current_parent,
+                                              const vector<Param>& params, shared_ptr<Pair>&& args);
+
+#endif //GLOM_EVAL_H

--- a/include/eval.h
+++ b/include/eval.h
@@ -19,13 +19,14 @@ class Expr;
 class Param;
 class Pair;
 class Context;
+class Continuation;
 
-
-/**
- * Eval Model
- * - Eval with expr in context
- *   - The result is EvalResult = expr | Continuation
- */
+class GlomCont : public std::exception {
+public:
+    unique_ptr<Continuation> cont;
+    shared_ptr<Expr> value;
+    explicit GlomCont(unique_ptr<Continuation> cont, shared_ptr<Expr> value);
+};
 
 shared_ptr<Expr> eval(const shared_ptr<Context>& ctx, shared_ptr<Expr> expr);
 shared_ptr<Expr> eval(const shared_ptr<Context>& ctx, shared_ptr<Pair> rest);

--- a/include/expr.h
+++ b/include/expr.h
@@ -89,6 +89,8 @@ struct Continuation
 {
     shared_ptr<Context> context;
     shared_ptr<Pair> exprs;
+    unique_ptr<string_view> callcc = nullptr;
+
 };
 
 using ExprValue = std::variant<
@@ -205,5 +207,8 @@ public:
 };
 
 
+shared_ptr<Expr> make_continuation(const shared_ptr<Context>& context, shared_ptr<Pair>&& exprs);
+
+shared_ptr<Expr> make_callcc(const shared_ptr<Context>& context, shared_ptr<Pair>&& exprs, string_view name);
 
 #endif //GLOM_EXPR_H

--- a/include/expr.h
+++ b/include/expr.h
@@ -162,7 +162,7 @@ public:
     [[nodiscard]] bool is_symbol() const;
     [[nodiscard]] bool is_primitive() const;
     [[nodiscard]] bool is_cont() const;
-
+    
     static const shared_ptr<Expr> TRUE;
     static const shared_ptr<Expr> FALSE;
     static const shared_ptr<Expr> NIL;

--- a/include/expr.h
+++ b/include/expr.h
@@ -85,7 +85,11 @@ public:
 
 string view_to_string(const string_view& view);
 
-
+struct Continuation
+{
+    shared_ptr<Context> context;
+    shared_ptr<Pair> exprs;
+};
 
 using ExprValue = std::variant<
     std::monostate,
@@ -97,7 +101,8 @@ using ExprValue = std::variant<
     string_view,             // symbol (interned)
     shared_ptr<Lambda>,
     shared_ptr<Primitive>,
-    shared_ptr<Pair>
+    shared_ptr<Pair>,
+    unique_ptr<Continuation>
 >;
 
 /**
@@ -109,10 +114,12 @@ using ExprValue = std::variant<
  * - Pair: Represents a pair of expressions.
  * - Lambda: Represents a lambda function. (Only constructed in runtime)
  * - Primitive: Represents a primitive members. (Only constructed in c++)
+ * - Continuation: Represents a continuation. (Only constructed in runtime)
  * - None: Represents None.
  */
 class Expr {
     ExprValue value;
+    explicit Expr(std::unique_ptr<Continuation>&& v);
     explicit Expr(shared_ptr<Pair>&& v);
     explicit Expr(shared_ptr<Lambda>&& v);
     explicit Expr(shared_ptr<Primitive>&& v);
@@ -135,6 +142,7 @@ public:
     [[nodiscard]] shared_ptr<Pair> as_pair() const;
     [[nodiscard]] shared_ptr<Lambda> as_lambda() const;
     [[nodiscard]] shared_ptr<Primitive> as_primitive() const;
+    [[nodiscard]] Continuation& as_cont() const;
     [[nodiscard]] string to_string() const;
     [[nodiscard]] bool to_boolean() const;
     [[nodiscard]] bool is_nil() const;
@@ -151,6 +159,7 @@ public:
     [[nodiscard]] bool is_lambda() const;
     [[nodiscard]] bool is_symbol() const;
     [[nodiscard]] bool is_primitive() const;
+    [[nodiscard]] bool is_cont() const;
 
     static const shared_ptr<Expr> TRUE;
     static const shared_ptr<Expr> FALSE;
@@ -166,6 +175,7 @@ public:
     static shared_ptr<Expr> make_lambda(shared_ptr<Lambda> v);
     static shared_ptr<Expr> make_primitive(shared_ptr<Primitive> v);
     static shared_ptr<Expr> make_pair(shared_ptr<Pair> v);
+    static shared_ptr<Expr> make_cont(unique_ptr<Continuation> v);
 };
 
 

--- a/include/expr.h
+++ b/include/expr.h
@@ -162,6 +162,7 @@ public:
     [[nodiscard]] bool is_symbol() const;
     [[nodiscard]] bool is_primitive() const;
     [[nodiscard]] bool is_cont() const;
+    void print() const;
     
     static const shared_ptr<Expr> TRUE;
     static const shared_ptr<Expr> FALSE;

--- a/include/parser.h
+++ b/include/parser.h
@@ -15,9 +15,10 @@ using std::unique_ptr;
 using std::shared_ptr;
 
 class Expr;
+class Pair;
 
 shared_ptr<Expr> parse_expr(string input);
-vector<shared_ptr<Expr>> parse(string input);
+shared_ptr<Pair> parse(string input);
 
 
 #endif //GLOM_PARSER_H

--- a/include/primitive.h
+++ b/include/primitive.h
@@ -41,8 +41,10 @@ namespace primitives_utils
     bool generic_num_gt(shared_ptr<Expr>& a, shared_ptr<Expr>& b);
     void coerce_number(shared_ptr<Expr>& a, shared_ptr<Expr>& b);
     void expect_1_arg(const string& proc, const shared_ptr<Pair>& args, shared_ptr<Expr>& a);
-    void expect_2_args(const string& name, const shared_ptr<Pair>& args, shared_ptr<Expr>& a, shared_ptr<Expr>& b);
-    void expect_2_or_3_args(const string& name, const shared_ptr<Pair>& args, shared_ptr<Expr>& a, shared_ptr<Expr>& b, shared_ptr<Expr>& c);
+    void expect_2_args(const string& proc, const shared_ptr<Pair>& args, shared_ptr<Expr>& a, shared_ptr<Expr>& b);
+    void expect_2_or_3_args(const string& proc, const shared_ptr<Pair>& args, shared_ptr<Expr>& a, shared_ptr<Expr>& b, shared_ptr<Expr>& c);
+    void take_car(const string& proc, const shared_ptr<Expr>& list, const shared_ptr<Expr>& expr, shared_ptr<Expr>& car);
+    void take_cdr(const string& proc, const shared_ptr<Expr>& list, const shared_ptr<Expr>& expr, shared_ptr<Expr>& cdr);
 }
 
 namespace primitives
@@ -132,7 +134,36 @@ namespace primitives
     shared_ptr<Expr> is_null(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
     shared_ptr<Expr> cons(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
     shared_ptr<Expr> car(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> caar(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> caaar(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> caaaar(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> caaadr(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> caadr(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> caadar(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> caaddr(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> cadr(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> cadar(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> cadaar(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> cadadr(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> caddr(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> caddar(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> cadddr(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
     shared_ptr<Expr> cdr(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> cdar(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> cdaar(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> cdaaar(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> cdaadr(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> cdadr(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> cdadar(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> cdaddr(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> cddr(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> cddar(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> cddaar(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> cddadr(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> cdddr(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> cdddar(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> cddddr(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
     shared_ptr<Expr> list(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> append(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
 }
 #endif //GLOM_PRIMITIVE_H

--- a/include/primitive.h
+++ b/include/primitive.h
@@ -37,6 +37,8 @@ public:
 namespace primitives_utils
 {
     bool generic_num_eq(shared_ptr<Expr>& a, shared_ptr<Expr>& b);
+    bool generic_num_lt(shared_ptr<Expr>& a, shared_ptr<Expr>& b);
+    bool generic_num_gt(shared_ptr<Expr>& a, shared_ptr<Expr>& b);
     void coerce_number(shared_ptr<Expr>& a, shared_ptr<Expr>& b);
     void expect_1_arg(const string& proc, const shared_ptr<Pair>& args, shared_ptr<Expr>& a);
     void expect_2_args(const string& name, const shared_ptr<Pair>& args, shared_ptr<Expr>& a, shared_ptr<Expr>& b);
@@ -56,15 +58,42 @@ namespace primitives
     shared_ptr<Expr> sub(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
     shared_ptr<Expr> mul(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
     shared_ptr<Expr> div(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> quotient(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
     shared_ptr<Expr> remainder(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
     shared_ptr<Expr> modulo(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
-    shared_ptr<Expr> power(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    // Math functions
+    shared_ptr<Expr> exponentiation(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> logarithm(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> sine(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> cosine(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> tangent(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> arcsine(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> arccosine(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> arctangent(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> square_root(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);;
+    shared_ptr<Expr> square_root_integer(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> exponential(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
     // Number comparisons
     shared_ptr<Expr> eq(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
     shared_ptr<Expr> lt(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
     shared_ptr<Expr> gt(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
     shared_ptr<Expr> le(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
     shared_ptr<Expr> ge(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    // Number utils
+    shared_ptr<Expr> is_zero(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> is_positive(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> is_negative(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> is_even(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> is_odd(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> max(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> min(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> abs(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> gcd(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> lcm(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> floor(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> ceiling(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> truncate(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> round(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
     // Logic operations
     shared_ptr<Expr> logical_and(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
     shared_ptr<Expr> logical_or(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
@@ -84,11 +113,22 @@ namespace primitives
     // Type
     shared_ptr<Expr> is_pair(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
     shared_ptr<Expr> is_number(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> is_boolean(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> is_symbol(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> is_string(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> is_exact(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> is_inexact(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> exact_to_inexact(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> inexact_to_exact(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> number_to_string(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> string_to_number(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> symbol_to_string(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> string_to_symbol(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
     // IO
     shared_ptr<Expr> display(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
     shared_ptr<Expr> read(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
     shared_ptr<Expr> newline(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
-    // List
+    // Pair
     shared_ptr<Expr> is_null(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
     shared_ptr<Expr> cons(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
     shared_ptr<Expr> car(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);

--- a/include/primitive.h
+++ b/include/primitive.h
@@ -9,7 +9,9 @@
 #include <vector>
 #include <string>
 #include <memory>
+#include "eval.h"
 
+struct Continuation;
 class Pair;
 class Context;
 class Expr;
@@ -34,6 +36,7 @@ public:
 
 namespace primitives_utils
 {
+    shared_ptr<Expr> continuation(const shared_ptr<Context>& context, shared_ptr<Pair>&& exprs);
     bool generic_num_eq(shared_ptr<Expr>& a, shared_ptr<Expr>& b);
     void coerce_number(shared_ptr<Expr>& a, shared_ptr<Expr>& b);
     void expect_1_arg(const string& proc, const shared_ptr<Pair>& args, shared_ptr<Expr>& a);

--- a/include/primitive.h
+++ b/include/primitive.h
@@ -52,7 +52,7 @@ namespace primitives
     // Eval Control
     shared_ptr<Expr> apply(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
     shared_ptr<Expr> callcc(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
-
+    shared_ptr<Expr> error(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
     // Quote
     shared_ptr<Expr> quote(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
     // Number operations

--- a/include/primitive.h
+++ b/include/primitive.h
@@ -127,6 +127,8 @@ namespace primitives
     shared_ptr<Expr> string_to_number(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
     shared_ptr<Expr> symbol_to_string(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
     shared_ptr<Expr> string_to_symbol(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> eq_string(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> eq_string_ignore_case(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
     // IO
     shared_ptr<Expr> display(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
     shared_ptr<Expr> read(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
@@ -166,5 +168,6 @@ namespace primitives
     shared_ptr<Expr> cddddr(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
     shared_ptr<Expr> list(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
     shared_ptr<Expr> append(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> length(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
 }
 #endif //GLOM_PRIMITIVE_H

--- a/include/primitive.h
+++ b/include/primitive.h
@@ -105,6 +105,7 @@ namespace primitives
     // New bindings
     shared_ptr<Expr> define(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
     shared_ptr<Expr> let(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> let_star(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
     // Condition
     shared_ptr<Expr> cond_if(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
     shared_ptr<Expr> cond(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);

--- a/include/primitive.h
+++ b/include/primitive.h
@@ -36,7 +36,6 @@ public:
 
 namespace primitives_utils
 {
-    shared_ptr<Expr> continuation(const shared_ptr<Context>& context, shared_ptr<Pair>&& exprs);
     bool generic_num_eq(shared_ptr<Expr>& a, shared_ptr<Expr>& b);
     void coerce_number(shared_ptr<Expr>& a, shared_ptr<Expr>& b);
     void expect_1_arg(const string& proc, const shared_ptr<Pair>& args, shared_ptr<Expr>& a);
@@ -48,6 +47,7 @@ namespace primitives
 {
     // Eval Control
     shared_ptr<Expr> apply(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
+    shared_ptr<Expr> callcc(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);
 
     // Quote
     shared_ptr<Expr> quote(const shared_ptr<Context>& context, shared_ptr<Pair>&& args);

--- a/include/tokenizer.h
+++ b/include/tokenizer.h
@@ -65,8 +65,8 @@ class Tokenizer
     string input;
     size_t index;
 
-    Token next_number();
     Token next_string();
+    Token next_number();
     Token next_symbol_or_boolean();
 
 public:

--- a/include/tokenizer.h
+++ b/include/tokenizer.h
@@ -64,6 +64,7 @@ class Tokenizer
 {
     string input;
     size_t index;
+    bool lang = false;
 
     Token next_string();
     Token next_number();

--- a/include/type.h
+++ b/include/type.h
@@ -28,6 +28,7 @@ constexpr auto SYMBOL = 6;
 constexpr auto LAMBDA = 7;
 constexpr auto PRIMITIVE = 8;
 constexpr auto PAIR = 9;
+constexpr auto CONTINUATION = 10;
 
 
 class rational;

--- a/include/type.h
+++ b/include/type.h
@@ -13,7 +13,6 @@ typedef __int128 int128_t;
 typedef unsigned __int128 uint128_t;
 
 #include <vector>
-#include <iostream>
 
 using std::variant;
 using std::pair;
@@ -35,6 +34,7 @@ class rational;
 using real = long double;
 
 real from_string(const std::string& str);
+std::string to_string(real val, size_t base = 10);
 
 class UBigInt
 {
@@ -97,10 +97,9 @@ public:
 
     bool operator<(uint64_t other) const;
 
-
-private:
     [[nodiscard]] std::pair<UBigInt, UBigInt> divide_single_word(uint64_t divisor) const;
 
+private:
     [[nodiscard]] std::pair<UBigInt, UBigInt> divide_long_division(const UBigInt& divisor) const;
 };
 
@@ -259,6 +258,8 @@ public:
 
     [[nodiscard]] BigInt to_bigint() const;
 
+    [[nodiscard]] std::variant<integer, real> sqrt() const;
+    [[nodiscard]] integer isqrt() const;
 };
 
 class rational {
@@ -320,8 +321,8 @@ public:
     [[nodiscard]] real to_inexact() const;
 
     static rational exact_rational(const integer& num, const integer& den);
+    static rational from_real(real r);
 };
-
 
 
 #endif //GLOM_TYPE_H

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -8,7 +8,17 @@
 
 
 Context::Context(shared_ptr<Context> parent, variables&& vars)
-    : parent(std::move(parent)), bindings(std::move(vars)) {}
+    : parent(std::move(parent)), bindings(std::move(vars))
+{
+    if (this->parent)
+    {
+        depth = this->parent->depth + 1;
+    }
+    else
+    {
+        depth = 0;
+    }
+}
 
 void Context::add(const string_view name, shared_ptr<Expr> value) {
     bindings[name] = std::move(value);

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -2,69 +2,18 @@
 // Created by glom on 9/26/25.
 //
 
+#include "eval.h"
+
+#include <utility>
+
 #include "context.h"
 #include "expr.h"
 #include "error.h"
 
-shared_ptr<Expr> Context::eval(shared_ptr<Expr> expr) {
-    if (!expr)
-    {
-        throw GlomError("Cannot evaluate null expression");
-    }
-    if (expr->is_symbol())
-    {
-        const auto& name = expr->as_symbol();
-        auto var = get(name);
-        if (!var)
-        {
-            throw GlomError("Undefined variable: " + view_to_string(name));
-        }
-        return var;
-    }
-    if (!expr->is_pair())
-    {
-        return std::move(expr);
-    }
-    const auto pair = expr->as_pair();
-    const auto proc = eval(std::move(pair->car()));
-    auto rest = pair->cdr();
-    shared_ptr<Pair> args = nullptr;
-    if (rest && rest->is_pair())
-    {
-        args = rest->as_pair();
-    } else if (rest)
-    {
-        args = Pair::single(std::move(rest));
-    }
-    if (proc->is_primitive())
-    {
-        const auto primitive = proc->as_primitive();
-        return (*primitive)(shared_from_this(),std::move(args));
-    }
-    if (proc->is_lambda())
-    {
-        const auto lambda = proc->as_lambda();
-        const auto& params = lambda->get_params();
-        const auto& body = lambda->get_body();
-        shared_ptr<Context> apply_context = nullptr;
-        if (params.empty())
-        {
-            apply_context = lambda->get_context();
-        } else
-        {
-            apply_context = eval_apply_context(proc, lambda->get_context(), params, std::move(args));
-        }
-        return apply_context->eval(body);
-    }
-    throw GlomError( proc->to_string() + " is not a procedure: " + expr->to_string());
-}
 
-
-
-
-shared_ptr<Context> Context::eval_apply_context(const shared_ptr<Expr>& proc, shared_ptr<Context> current_parent, const vector<Param>& params, shared_ptr<Pair>&& args)
+shared_ptr<Context> eval_apply_context(const shared_ptr<Context>& ctx, const shared_ptr<Expr>& proc, const shared_ptr<Context>& current_parent, const vector<Param>& params, shared_ptr<Pair>&& args)
 {
-    auto context = new_context(std::move(current_parent));
+    auto context = Context::new_context(current_parent);
     shared_ptr<Pair> rest = std::move(args);
     size_t index = 0;
     while (index != params.size() && !rest->empty())
@@ -77,7 +26,7 @@ shared_ptr<Context> Context::eval_apply_context(const shared_ptr<Expr>& proc, sh
             index = params.size();
             break;
         }
-        const auto arg = this->eval(rest->car());
+        const auto arg = eval(ctx, rest->car());
         rest = rest->cdr()->as_pair();
         context->add(name, arg);
         index++;
@@ -87,26 +36,107 @@ shared_ptr<Context> Context::eval_apply_context(const shared_ptr<Expr>& proc, sh
         throw GlomError("Incorrect number of arguments provided for " + proc->to_string());
     }
 
-    return std::move(context);
-}
-shared_ptr<Expr> Context::eval(const shared_ptr<Pair>& exprs)
-{
-    shared_ptr<Expr> current = nullptr;
-    for (const auto expr : *exprs)
-    {
-        if (!expr) break;
-        current = eval(expr);
-    }
-    return current;
+    return context;
 }
 
-
-shared_ptr<Expr> Context::eval(const vector<shared_ptr<Expr>>& exprs)
+shared_ptr<Expr> eval(const shared_ptr<Context>& ctx, shared_ptr<Expr> expr)
 {
-    shared_ptr<Expr> current = nullptr;
-    for (auto& expr : exprs)
+    auto body = Pair::single(std::move(expr));
+    return eval(ctx, std::move(body));
+}
+
+shared_ptr<Expr> eval(const shared_ptr<Context>& ctx, shared_ptr<Pair> exprs)
+{
+    auto current_ctx = ctx;
+    shared_ptr<Expr> expr = nullptr;
+    exprs = std::move(exprs);
+    if (exprs->empty())
     {
-        current = eval(expr);
+        throw GlomError("Cannot evaluate null expression");
     }
-    return current;
+    bool tail = false;
+    while (true)
+    {
+        expr = exprs->car();
+        exprs = exprs->cdr()->as_pair();
+        if (!tail)
+            tail = exprs->empty();
+        if (expr->is_symbol())
+        {
+            const auto& name = expr->as_symbol();
+            auto var = current_ctx->get(name);
+            if (!var)
+            {
+                throw GlomError("Undefined variable: " + view_to_string(name));
+            }
+            if (tail)
+            {
+                return var;
+            }
+            continue;
+        }
+        if (!expr->is_pair())
+        {
+            if (tail)
+            {
+                return std::move(expr);
+            }
+            continue;
+        }
+        const auto pair = expr->as_pair();
+        const auto proc = eval(current_ctx,std::move(pair->car()));
+        auto rest = pair->cdr();
+        shared_ptr<Pair> args = nullptr;
+        if (rest && rest->is_pair())
+        {
+            args = rest->as_pair();
+        }
+        else if (rest)
+        {
+            args = Pair::single(std::move(rest));
+        }
+        if (proc->is_primitive())
+        {
+            const auto primitive = proc->as_primitive();
+            auto result = (*primitive)(current_ctx,std::move(args));
+            if (result->is_cont())
+            {
+                auto& [cont_ctx, cont_exprs] = result->as_cont();
+                if (tail)
+                {
+                    current_ctx = cont_ctx;
+                    exprs = cont_exprs;
+                    continue;
+                }
+                eval(cont_ctx, std::move(cont_exprs));
+            }
+            if (tail)
+            {
+                return result;
+            }
+        }
+        if (proc->is_lambda())
+        {
+            const auto lambda = proc->as_lambda();
+            const auto& params = lambda->get_params();
+            const auto& body = lambda->get_body();
+            shared_ptr<Context> apply_context = nullptr;
+            if (params.empty())
+            {
+                apply_context = lambda->get_context();
+            }
+            else
+            {
+                apply_context = eval_apply_context(current_ctx, proc, lambda->get_context(), params, std::move(args));
+            }
+            if (tail)
+            {
+                current_ctx = apply_context;
+                exprs = body;
+                continue;
+            }
+            eval(apply_context, body);
+        }
+        throw GlomError( proc->to_string() + " is not a procedure: " + expr->to_string());
+    }
 }

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -22,7 +22,29 @@ shared_ptr<Context> eval_apply_context(const shared_ptr<Context>& ctx, const sha
         const auto& name = param.get_name();
         if (param.is_vararg())
         {
-            context->add(name, Expr::make_pair(std::move(rest)));
+            shared_ptr<Pair> varargs = nullptr;
+            shared_ptr<Pair> tail = nullptr;
+            for (const auto arg : *rest)
+            {
+                if (!arg) break;
+                auto vararg = eval(ctx, arg);
+                if (!varargs)
+                {
+                    varargs = Pair::single(std::move(vararg));
+                    tail = varargs;
+                }
+                else
+                {
+                    const auto tail_pair = Pair::single(std::move(vararg));
+                    tail->set_cdr(Expr::make_pair(tail_pair));
+                    tail = tail_pair;
+                }
+            }
+            if (!varargs)
+            {
+                varargs = Pair::EMPTY;
+            }
+            context->add(name, Expr::make_pair(std::move(varargs)));
             index = params.size();
             break;
         }

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -424,6 +424,12 @@ string Lambda::to_string() const
     return result;
 }
 
+void Expr::print() const
+{
+    if (is_nothing())
+        return;
+    printf("%s\n", to_string().data());
+}
 
 string Expr::to_string() const
 {
@@ -448,7 +454,7 @@ string Expr::to_string() const
         case LAMBDA:
             return as_lambda()->to_string();
         case PRIMITIVE:
-            return "<primitive:" + as_primitive()->get_name();
+            return "<primitive:" + as_primitive()->get_name() + ">";
         case CONTINUATION:
             return "<continuation>";
         default:

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -444,7 +444,7 @@ string Expr::to_string() const
         case NUMBER_REAL:
             return std::to_string(as_number_real());
         case STRING:
-            return "\"" + as_string() + "\"";
+            return as_string();
         case BOOLEAN:
             return as_boolean() ? "true" : "false";
         case SYMBOL:

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -128,6 +128,7 @@ Expr::Expr(shared_ptr<Pair>&& v) : value(std::move(v)) {}
 Expr::Expr(shared_ptr<Lambda>&& v) : value(std::move(v)) {}
 Expr::Expr(shared_ptr<Primitive>&& v) : value(std::move(v)) {}
 Expr::Expr(std::unique_ptr<string>&& v) : value(std::move(v)) {}
+Expr::Expr(std::unique_ptr<Continuation>&& v) : value(std::move(v)) {}
 Expr::Expr(const string_view v): value(v) {}
 
 
@@ -179,6 +180,10 @@ bool Expr::is_lambda() const
 bool Expr::is_primitive() const
 {
     return value.index() == PRIMITIVE;
+}
+bool Expr::is_cont() const
+{
+    return value.index() == CONTINUATION;
 }
 
 bool Expr::as_boolean() const
@@ -251,6 +256,11 @@ shared_ptr<Lambda> Expr::as_lambda() const
 shared_ptr<Primitive> Expr::as_primitive() const
 {
     return std::get<shared_ptr<Primitive>>(value);
+}
+
+Continuation& Expr::as_cont() const
+{
+    return *std::get<std::unique_ptr<Continuation>>(value);
 }
 
 bool Expr::to_boolean() const
@@ -361,6 +371,10 @@ shared_ptr<Expr> Expr::make_pair(shared_ptr<Pair> v)
 {
     return std::make_shared<Expr>(Expr(std::move(v)));
 }
+shared_ptr<Expr> Expr::make_cont(unique_ptr<Continuation> v)
+{
+    return std::make_shared<Expr>(Expr(std::move(v)));
+}
 
 
 Lambda::Lambda(vector<Param>&& params, shared_ptr<Pair> body, shared_ptr<Context> context)
@@ -425,6 +439,8 @@ string Expr::to_string() const
             return as_lambda()->to_string();
         case PRIMITIVE:
             return "<primitive:" + as_primitive()->get_name();
+        case CONTINUATION:
+            return "<continuation>";
         default:
             return "Unknown";
     }

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -377,6 +377,16 @@ shared_ptr<Expr> Expr::make_cont(unique_ptr<Continuation> v)
 }
 
 
+shared_ptr<Expr> make_continuation(const shared_ptr<Context>& context, shared_ptr<Pair>&& exprs)
+{
+    return Expr::make_cont(std::make_unique<Continuation>(context, std::move(exprs)));
+}
+
+shared_ptr<Expr> make_callcc(const shared_ptr<Context>& context, shared_ptr<Pair>&& exprs, string_view name)
+{
+    return Expr::make_cont(std::make_unique<Continuation>(context, std::move(exprs), std::make_unique<string_view>(name)));
+}
+
 Lambda::Lambda(vector<Param>&& params, shared_ptr<Pair> body, shared_ptr<Context> context)
     : params(std::move(params)), body(std::move(body)), context(std::move(context)) {}
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,7 +2,6 @@
 #include <string>
 #include <memory>
 #include <sstream>
-#include <vector>
 
 #include "parser.h"
 #include "context.h"
@@ -57,10 +56,6 @@ public:
                 break;
             case '"':
                 in_string = true;
-                break;
-            case ';':
-                // Skip comments until end of line
-                // Comments don't affect paren balancing
                 break;
             default:
                 break;
@@ -199,14 +194,13 @@ void repl()
 
         try
         {
-            auto exprs = parse(input);
+            const auto exprs = parse(input);
             if (!exprs || exprs->empty())
             {
                 continue;
             }
 
-            const auto result = eval(context, exprs);
-            if (result)
+            if (const auto result = eval(context, exprs))
             {
                 std::cout << result->to_string() << '\n';
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -150,12 +150,12 @@ void repl()
         try
         {
             auto exprs = parse(input);
-            if (exprs.empty())
+            if (exprs->empty())
             {
                 continue;
             }
 
-            const auto result = context->eval(exprs);
+            const auto result = eval(context, exprs);
             std::cout << result->to_string() << '\n';
         }
         catch (const std::exception& e)

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -110,7 +110,7 @@ public:
 
 shared_ptr<Expr> parse_expr(string input)
 {
-    auto exprs = parse(std::move(input));
+    const auto exprs = parse(std::move(input));
     if (exprs->empty())
     {
         throw std::runtime_error("Expected a single expression, got " + exprs->to_string());

--- a/src/primitive.cpp
+++ b/src/primitive.cpp
@@ -110,6 +110,7 @@ void add_list_operations(Context& builder)
 void add_eval_control(Context& builder)
 {
     builder.add_primitive("apply", primitives::apply);
+    builder.add_primitive("call/cc", primitives::callcc);
 }
 
 

--- a/src/primitive.cpp
+++ b/src/primitive.cpp
@@ -150,9 +150,38 @@ void add_list_operations(Context& builder)
 {
     builder.add_primitive("cons", primitives::cons);
     builder.add_primitive("car", primitives::car);
+    builder.add_primitive("caar", primitives::caar);
+    builder.add_primitive("caaar", primitives::caaar);
+    builder.add_primitive("caaaar", primitives::caaaar);
+    builder.add_primitive("caaadr", primitives::caaadr);
+    builder.add_primitive("caadr", primitives::caadr);
+    builder.add_primitive("caadar", primitives::caadar);
+    builder.add_primitive("caaddr", primitives::caaddr);
+    builder.add_primitive("cadr", primitives::cadr);
+    builder.add_primitive("cadar", primitives::cadar);
+    builder.add_primitive("cadaar", primitives::cadaar);
+    builder.add_primitive("cadadr", primitives::cadadr);
+    builder.add_primitive("caddr", primitives::caddr);
+    builder.add_primitive("caddar", primitives::caddar);
+    builder.add_primitive("cadddr", primitives::cadddr);
     builder.add_primitive("cdr", primitives::cdr);
+    builder.add_primitive("cdar", primitives::cdar);
+    builder.add_primitive("cdaar", primitives::cdaar);
+    builder.add_primitive("cdaaar", primitives::cdaaar);
+    builder.add_primitive("cdaadr", primitives::cdaadr);
+    builder.add_primitive("cdadr", primitives::cdadr);
+    builder.add_primitive("cdadar", primitives::cdadar);
+    builder.add_primitive("cdaddr", primitives::cdaddr);
+    builder.add_primitive("cddr", primitives::cddr);
+    builder.add_primitive("cddar", primitives::cddar);
+    builder.add_primitive("cddaar", primitives::cddaar);
+    builder.add_primitive("cddadr", primitives::cddadr);
+    builder.add_primitive("cdddr", primitives::cdddr);
+    builder.add_primitive("cdddar", primitives::cdddar);
+    builder.add_primitive("cddddr", primitives::cddddr);
     builder.add_primitive("list", primitives::list);
     builder.add_primitive("null?", primitives::is_null);
+    builder.add_primitive("append", primitives::append);
 }
 
 void add_eval_control(Context& builder)

--- a/src/primitive.cpp
+++ b/src/primitive.cpp
@@ -135,6 +135,8 @@ void add_ptr_comparator(Context& builder)
     builder.add_primitive("eq?", primitives::eq_ptr);
     builder.add_primitive("eqv?", primitives::eq_val);
     builder.add_primitive("equal?", primitives::eq_struct);
+    builder.add_primitive("string=?", primitives::eq_string);
+    builder.add_primitive("string-ci=?", primitives::eq_string_ignore_case);
 }
 
 void add_condition(Context& builder)
@@ -185,6 +187,7 @@ void add_list_operations(Context& builder)
     builder.add_primitive("list", primitives::list);
     builder.add_primitive("null?", primitives::is_null);
     builder.add_primitive("append", primitives::append);
+    builder.add_primitive("length", primitives::length);
 }
 
 void add_eval_control(Context& builder)

--- a/src/primitive.cpp
+++ b/src/primitive.cpp
@@ -39,9 +39,57 @@ void add_number_operations(Context& builder)
     builder.add_primitive("*", primitives::mul);
     builder.add_primitive("-", primitives::sub);
     builder.add_primitive("/", primitives::div);
+    builder.add_primitive("quotient", primitives::quotient);
     builder.add_primitive("modulo", primitives::modulo);
     builder.add_primitive("remainder", primitives::remainder);
-    builder.add_primitive("expt", primitives::power);
+    builder.add_primitive("expt", primitives::exponential);
+}
+
+void add_number_utils(Context& builder)
+{
+    builder.add_primitive("zero?", primitives::is_zero);
+    builder.add_primitive("positive?", primitives::is_positive);
+    builder.add_primitive("negative?", primitives::is_negative);
+    builder.add_primitive("even?", primitives::is_even);
+    builder.add_primitive("odd?", primitives::is_odd);
+    builder.add_primitive("max", primitives::max);
+    builder.add_primitive("min", primitives::min);
+    builder.add_primitive("abs", primitives::abs);
+    builder.add_primitive("gcd", primitives::gcd);
+    builder.add_primitive("lcm", primitives::lcm);
+    builder.add_primitive("floor", primitives::floor);
+    builder.add_primitive("ceiling", primitives::ceiling);
+    builder.add_primitive("truncate", primitives::truncate);
+    builder.add_primitive("round", primitives::round);
+}
+
+void add_math_functions(Context& builder)
+{
+    builder.add_primitive("sqrt", primitives::square_root);
+    builder.add_primitive("isqrt", primitives::square_root_integer);
+    builder.add_primitive("log", primitives::logarithm);
+    builder.add_primitive("sin", primitives::sine);
+    builder.add_primitive("cos", primitives::cosine);
+    builder.add_primitive("tan", primitives::tangent);
+    builder.add_primitive("asin", primitives::arcsine);
+    builder.add_primitive("acos", primitives::arccosine);
+    builder.add_primitive("atan", primitives::arctangent);
+    builder.add_primitive("exp", primitives::exponentiation);
+}
+
+void add_type_utils(Context& builder)
+{
+    builder.add_primitive("pair?", primitives::is_pair);
+    builder.add_primitive("number?", primitives::is_number);
+    builder.add_primitive("boolean?", primitives::is_boolean);
+    builder.add_primitive("symbol?", primitives::is_symbol);
+    builder.add_primitive("string?", primitives::is_string);
+    builder.add_primitive("exact?", primitives::is_exact);
+    builder.add_primitive("inexact?", primitives::is_inexact);
+    builder.add_primitive("exact->inexact", primitives::exact_to_inexact);
+    builder.add_primitive("inexact->exact", primitives::inexact_to_exact);
+    builder.add_primitive("number->string", primitives::number_to_string);
+    builder.add_primitive("string->number", primitives::string_to_number);
 }
 
 void add_quote_operation(Context& builder)
@@ -121,6 +169,9 @@ shared_ptr<Context> make_root_context()
     add_ptr_comparator(*context);
     add_number_operations(*context);
     add_number_comparators(*context);
+    add_number_utils(*context);
+    add_math_functions(*context);
+    add_type_utils(*context);
     add_logic_operations(*context);
     add_quote_operation(*context);
     add_lambda(*context);

--- a/src/primitive.cpp
+++ b/src/primitive.cpp
@@ -90,6 +90,8 @@ void add_type_utils(Context& builder)
     builder.add_primitive("inexact->exact", primitives::inexact_to_exact);
     builder.add_primitive("number->string", primitives::number_to_string);
     builder.add_primitive("string->number", primitives::string_to_number);
+    builder.add_primitive("symbol->string", primitives::symbol_to_string);
+    builder.add_primitive("string->symbol", primitives::string_to_symbol);
 }
 
 void add_quote_operation(Context& builder)
@@ -106,6 +108,7 @@ void add_new_bindings(Context& builder)
 {
     builder.add_primitive("define", primitives::define);
     builder.add_primitive("let", primitives::let);
+    builder.add_primitive("let*", primitives::let_star);
 }
 
 void add_number_comparators(Context& builder)

--- a/src/primitive.cpp
+++ b/src/primitive.cpp
@@ -188,6 +188,7 @@ void add_eval_control(Context& builder)
 {
     builder.add_primitive("apply", primitives::apply);
     builder.add_primitive("call/cc", primitives::callcc);
+    builder.add_primitive("error", primitives::error);
 }
 
 

--- a/src/primitives/condition.cpp
+++ b/src/primitives/condition.cpp
@@ -11,13 +11,13 @@ shared_ptr<Expr> primitives::cond_if(const shared_ptr<Context>& context, shared_
 {
     shared_ptr<Expr> cond, then, otherwise = nullptr;
     primitives_utils::expect_2_or_3_args("if", args, cond, then, otherwise);
-    if (const auto evaluated_cond = context->eval(cond); evaluated_cond->to_boolean())
+    if (const auto evaluated_cond = eval(context, cond); evaluated_cond->to_boolean())
     {
-        return context->eval(then);
+        return primitives_utils::continuation(context, Pair::single(std::move(then)));
     }
     if (otherwise != nullptr)
     {
-        return context->eval(otherwise);
+        return primitives_utils::continuation(context, Pair::single(std::move(otherwise)));
     }
     return Expr::NOTHING;
 }
@@ -49,7 +49,7 @@ shared_ptr<Expr> primitives::cond(const shared_ptr<Context>& context, shared_ptr
         }
         else
         {
-            evaluated_condition = context->eval(condition);
+            evaluated_condition = eval(context, condition);
             test = evaluated_condition->to_boolean();
         }
         if (!test)
@@ -61,12 +61,16 @@ shared_ptr<Expr> primitives::cond(const shared_ptr<Context>& context, shared_ptr
             return evaluated_condition;
         }
         auto body_expr = clause_pair->cdr();
+        shared_ptr<Pair> body = nullptr;
         if (body_expr->is_pair())
         {
-            const auto body = body_expr->as_pair();
-            return context->eval(body);
+            body = body_expr->as_pair();
         }
-        return context->eval(std::move(body_expr));
+        else
+        {
+            body = Pair::single(std::move(body_expr));
+        }
+        return primitives_utils::continuation(context, std::move(body));
     }
     return Expr::NOTHING;
 }

--- a/src/primitives/condition.cpp
+++ b/src/primitives/condition.cpp
@@ -13,11 +13,11 @@ shared_ptr<Expr> primitives::cond_if(const shared_ptr<Context>& context, shared_
     primitives_utils::expect_2_or_3_args("if", args, cond, then, otherwise);
     if (const auto evaluated_cond = eval(context, cond); evaluated_cond->to_boolean())
     {
-        return primitives_utils::continuation(context, Pair::single(std::move(then)));
+        return make_continuation(context, Pair::single(std::move(then)));
     }
     if (otherwise != nullptr)
     {
-        return primitives_utils::continuation(context, Pair::single(std::move(otherwise)));
+        return make_continuation(context, Pair::single(std::move(otherwise)));
     }
     return Expr::NOTHING;
 }
@@ -70,7 +70,7 @@ shared_ptr<Expr> primitives::cond(const shared_ptr<Context>& context, shared_ptr
         {
             body = Pair::single(std::move(body_expr));
         }
-        return primitives_utils::continuation(context, std::move(body));
+        return make_continuation(context, std::move(body));
     }
     return Expr::NOTHING;
 }

--- a/src/primitives/equal.cpp
+++ b/src/primitives/equal.cpp
@@ -24,8 +24,8 @@ shared_ptr<Expr> primitives::eq_ptr(const shared_ptr<Context>& context, shared_p
 {
     shared_ptr<Expr> a, b = nullptr;
     primitives_utils::expect_2_args("eq?", args, a, b);
-    a = context->eval(a);
-    b = context->eval(b);
+    a = eval(context, a);
+    b = eval(context, b);
     return Expr::make_boolean(eq_ptr_impl(a,b));
 }
 
@@ -53,8 +53,8 @@ shared_ptr<Expr> primitives::eq_val(const shared_ptr<Context>& context, shared_p
 {
     shared_ptr<Expr> a, b = nullptr;
     primitives_utils::expect_2_args("eqv?", args, a, b);
-    a = context->eval(a);
-    b = context->eval(b);
+    a = eval(context, a);
+    b = eval(context, b);
     if (eq_ptr_impl(a,b)) return Expr::TRUE;
     return Expr::make_boolean(equal_value_internal(a, b));
 }
@@ -89,8 +89,8 @@ shared_ptr<Expr> primitives::eq_struct(const shared_ptr<Context>& context, share
 {
     shared_ptr<Expr> a, b = nullptr;
     primitives_utils::expect_2_args("equal?", args, a, b);
-    a = context->eval(a);
-    b = context->eval(b);
+    a = eval(context, a);
+    b = eval(context, b);
     if (eq_ptr_impl(a,b)) return Expr::TRUE;
     unordered_map<const Expr*, const Expr*> visited;
     visited.reserve(32);

--- a/src/primitives/evaluate_control.cpp
+++ b/src/primitives/evaluate_control.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "context.h"
+#include "error.h"
 #include "expr.h"
 #include "primitive.h"
 
@@ -14,4 +15,26 @@ shared_ptr<Expr> primitives::apply(const shared_ptr<Context>& context, shared_pt
     proc_args = eval(context, proc_args);
     const auto apply = Expr::make_pair(Pair::cons(proc,proc_args));
     return eval(context, apply);
+}
+
+shared_ptr<Expr> primitives::callcc(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> proc;
+    primitives_utils::expect_1_arg("call/cc", args, proc);
+    proc = eval(context, proc);
+    if (!proc->is_lambda())
+        throw GlomError("call/cc: argument is not a procedure");
+
+    const auto lambda = proc->as_lambda();
+    const auto params = lambda->get_params();
+    if (params.size() != 1)
+        throw GlomError("call/cc: procedure must take exactly one argument");
+    const auto param = params[0];
+    if (param.is_vararg())
+        throw GlomError("call/cc: procedure argument cannot be vararg");
+    const auto param_name = param.get_name();
+    const auto ctx = lambda->get_context();
+    auto body = lambda->get_body();
+    auto cont = make_callcc(ctx, std::move(body), param_name);
+    return cont;
 }

--- a/src/primitives/evaluate_control.cpp
+++ b/src/primitives/evaluate_control.cpp
@@ -10,8 +10,8 @@ shared_ptr<Expr> primitives::apply(const shared_ptr<Context>& context, shared_pt
 {
     shared_ptr<Expr> proc, proc_args;
     primitives_utils::expect_2_args("apply", args, proc, proc_args);
-    proc = context->eval(proc);
-    proc_args = context->eval(proc_args);
+    proc = eval(context, proc);
+    proc_args = eval(context, proc_args);
     const auto apply = Expr::make_pair(Pair::cons(proc,proc_args));
-    return context->eval(apply);
+    return eval(context, apply);
 }

--- a/src/primitives/evaluate_control.cpp
+++ b/src/primitives/evaluate_control.cpp
@@ -38,3 +38,20 @@ shared_ptr<Expr> primitives::callcc(const shared_ptr<Context>& context, shared_p
     auto cont = make_callcc(ctx, std::move(body), param_name);
     return cont;
 }
+
+//error
+shared_ptr<Expr> primitives::error(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    if (args->empty())
+        throw GlomError("error: at least one argument required");
+    std::string message;
+    for (const auto& arg : *args)
+    {
+        if (!arg) break;
+        if (message.empty())
+            message = arg->to_string();
+        else
+            message += " " + arg->to_string();
+    }
+    throw GlomError("Error: " + message);
+}

--- a/src/primitives/io.cpp
+++ b/src/primitives/io.cpp
@@ -19,7 +19,7 @@ shared_ptr<Expr> primitives::display(const shared_ptr<Context>& context, shared_
     for (auto expr : *args)
     {
         if (!expr) break;
-        const auto arg = context->eval(std::move(expr));
+        const auto arg = eval(context, std::move(expr));
         std::cout << arg->to_string();
     }
     return Expr::NOTHING;

--- a/src/primitives/io.cpp
+++ b/src/primitives/io.cpp
@@ -20,7 +20,7 @@ shared_ptr<Expr> primitives::display(const shared_ptr<Context>& context, shared_
     {
         if (!expr) break;
         const auto arg = eval(context, std::move(expr));
-        std::cout << arg->to_string();
+        printf("%s", arg->to_string().c_str());
     }
     return Expr::NOTHING;
 }
@@ -44,6 +44,6 @@ shared_ptr<Expr> primitives::newline(const shared_ptr<Context>& context, shared_
     {
         throw GlomError("incorrect argument count in call newline: expected 0 arguments");
     }
-    std::cout << std::endl;
+    printf("\n");
     return Expr::NOTHING;
 }

--- a/src/primitives/list.cpp
+++ b/src/primitives/list.cpp
@@ -432,3 +432,27 @@ shared_ptr<Expr> primitives::append(const shared_ptr<Context>& context, shared_p
         return Expr::NIL;
     return Expr::make_pair(result);
 }
+
+// length
+shared_ptr<Expr> primitives::length(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> list_expr = nullptr;
+    primitives_utils::expect_1_arg("length", args, list_expr);
+    list_expr = eval(context, list_expr);
+    if (list_expr->is_nil())
+    {
+        return Expr::make_number_int(integer(0));
+    }
+    if (!list_expr->is_pair())
+    {
+        throw GlomError("length: argument is not a list: " + list_expr->to_string());
+    }
+    const auto list = list_expr->as_pair();
+    int64_t len = 0;
+    for (const auto& _ : *list)
+    {
+        if (!_ ) break;
+        len++;
+    }
+    return Expr::make_number_int(integer(len));
+}

--- a/src/primitives/list.cpp
+++ b/src/primitives/list.cpp
@@ -27,17 +27,171 @@ shared_ptr<Expr> primitives::car(const shared_ptr<Context>& context, shared_ptr<
     shared_ptr<Expr> pair_expr = nullptr;
     primitives_utils::expect_1_arg("car", args, pair_expr);
     pair_expr = eval(context, pair_expr);
-    if (!pair_expr->is_pair())
-    {
-        throw GlomError("car: argument is not a pair");
-    }
-    const auto pair = pair_expr->as_pair();
-    if (pair->empty())
-    {
-        throw GlomError("car: cannot take car of empty list");
-    }
-    return pair->car();
+    shared_ptr<Expr> car_expr = nullptr;
+    primitives_utils::take_car("car", pair_expr, pair_expr, car_expr);
+    return car_expr;
 }
+shared_ptr<Expr> primitives::caar(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> pair_expr = nullptr;
+    primitives_utils::expect_1_arg("caar", args, pair_expr);
+    pair_expr = eval(context, pair_expr);
+    shared_ptr<Expr> rest = pair_expr;
+    primitives_utils::take_car("caar", pair_expr, rest, rest);
+    primitives_utils::take_car("caar", pair_expr, rest, rest);
+    return rest;
+}
+shared_ptr<Expr> primitives::caaar(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> pair_expr = nullptr;
+    primitives_utils::expect_1_arg("caaar", args, pair_expr);
+    pair_expr = eval(context, pair_expr);
+    shared_ptr<Expr> rest = pair_expr;
+    primitives_utils::take_car("caaar", pair_expr, rest, rest);
+    primitives_utils::take_car("caaar", pair_expr, rest, rest);
+    primitives_utils::take_car("caaar", pair_expr, rest, rest);
+    return rest;
+}
+shared_ptr<Expr> primitives::caaaar(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> pair_expr = nullptr;
+    primitives_utils::expect_1_arg("caaaar", args, pair_expr);
+    pair_expr = eval(context, pair_expr);
+    shared_ptr<Expr> rest = pair_expr;
+    primitives_utils::take_car("caaaar", pair_expr, rest, rest);
+    primitives_utils::take_car("caaaar", pair_expr, rest, rest);
+    primitives_utils::take_car("caaaar", pair_expr, rest, rest);
+    primitives_utils::take_car("caaaar", pair_expr, rest, rest);
+    return rest;
+}
+shared_ptr<Expr> primitives::caaadr(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> pair_expr = nullptr;
+    primitives_utils::expect_1_arg("caaadr", args, pair_expr);
+    pair_expr = eval(context, pair_expr);
+    shared_ptr<Expr> rest = pair_expr;
+    primitives_utils::take_cdr("caaadr", pair_expr, rest, rest);
+    primitives_utils::take_car("caaadr", pair_expr, rest, rest);
+    primitives_utils::take_car("caaadr", pair_expr, rest, rest);
+    primitives_utils::take_car("caaadr", pair_expr, rest, rest);
+    return rest;
+}
+shared_ptr<Expr> primitives::caadr(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> pair_expr = nullptr;
+    primitives_utils::expect_1_arg("caadr", args, pair_expr);
+    pair_expr = eval(context, pair_expr);
+    shared_ptr<Expr> rest = pair_expr;
+    primitives_utils::take_cdr("caadr", pair_expr, rest, rest);
+    primitives_utils::take_car("caadr", pair_expr, rest, rest);
+    primitives_utils::take_car("caadr", pair_expr, rest, rest);
+    return rest;
+}
+shared_ptr<Expr> primitives::caadar(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> pair_expr = nullptr;
+    primitives_utils::expect_1_arg("caadar", args, pair_expr);
+    pair_expr = eval(context, pair_expr);
+    shared_ptr<Expr> rest = pair_expr;
+    primitives_utils::take_car("caadar", pair_expr, rest, rest);
+    primitives_utils::take_cdr("caadar", pair_expr, rest, rest);
+    primitives_utils::take_car("caadar", pair_expr, rest, rest);
+    primitives_utils::take_car("caadar", pair_expr, rest, rest);
+    return rest;
+}
+shared_ptr<Expr> primitives::caaddr(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> pair_expr = nullptr;
+    primitives_utils::expect_1_arg("caaddr", args, pair_expr);
+    pair_expr = eval(context, pair_expr);
+    shared_ptr<Expr> rest = pair_expr;
+    primitives_utils::take_cdr("caaddr", pair_expr, rest, rest);
+    primitives_utils::take_cdr("caaddr", pair_expr, rest, rest);
+    primitives_utils::take_car("caaddr", pair_expr, rest, rest);
+    primitives_utils::take_car("caaddr", pair_expr, rest, rest);
+    return rest;
+}
+shared_ptr<Expr> primitives::cadr(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> pair_expr = nullptr;
+    primitives_utils::expect_1_arg("cadr", args, pair_expr);
+    pair_expr = eval(context, pair_expr);
+    shared_ptr<Expr> rest = pair_expr;
+    primitives_utils::take_cdr("cadr", pair_expr, rest, rest);
+    primitives_utils::take_car("cadr", pair_expr, rest, rest);
+    return rest;
+}
+shared_ptr<Expr> primitives::cadar(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> pair_expr = nullptr;
+    primitives_utils::expect_1_arg("cadar", args, pair_expr);
+    pair_expr = eval(context, pair_expr);
+    shared_ptr<Expr> rest = pair_expr;
+    primitives_utils::take_car("cadar", pair_expr, rest, rest);
+    primitives_utils::take_cdr("cadar", pair_expr, rest, rest);
+    primitives_utils::take_car("cadar", pair_expr, rest, rest);
+    return rest;
+}
+shared_ptr<Expr> primitives::cadaar(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> pair_expr = nullptr;
+    primitives_utils::expect_1_arg("cadaar", args, pair_expr);
+    pair_expr = eval(context, pair_expr);
+    shared_ptr<Expr> rest = pair_expr;
+    primitives_utils::take_car("cadaar", pair_expr, rest, rest);
+    primitives_utils::take_car("cadaar", pair_expr, rest, rest);
+    primitives_utils::take_cdr("cadaar", pair_expr, rest, rest);
+    primitives_utils::take_car("cadaar", pair_expr, rest, rest);
+    return rest;
+}
+shared_ptr<Expr> primitives::cadadr(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> pair_expr = nullptr;
+    primitives_utils::expect_1_arg("cadadr", args, pair_expr);
+    pair_expr = eval(context, pair_expr);
+    shared_ptr<Expr> rest = pair_expr;
+    primitives_utils::take_cdr("cadadr", pair_expr, rest, rest);
+    primitives_utils::take_car("cadadr", pair_expr, rest, rest);
+    primitives_utils::take_cdr("cadadr", pair_expr, rest, rest);
+    primitives_utils::take_car("cadadr", pair_expr, rest, rest);
+    return rest;
+}
+shared_ptr<Expr> primitives::caddr(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> pair_expr = nullptr;
+    primitives_utils::expect_1_arg("caddr", args, pair_expr);
+    pair_expr = eval(context, pair_expr);
+    shared_ptr<Expr> rest = pair_expr;
+    primitives_utils::take_cdr("caddr", pair_expr, rest, rest);
+    primitives_utils::take_cdr("caddr", pair_expr, rest, rest);
+    primitives_utils::take_car("caddr", pair_expr, rest, rest);
+    return rest;
+}
+shared_ptr<Expr> primitives::caddar(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> pair_expr = nullptr;
+    primitives_utils::expect_1_arg("caddar", args, pair_expr);
+    pair_expr = eval(context, pair_expr);
+    shared_ptr<Expr> rest = pair_expr;
+    primitives_utils::take_car("caddar", pair_expr, rest, rest);
+    primitives_utils::take_cdr("caddar", pair_expr, rest, rest);
+    primitives_utils::take_cdr("caddar", pair_expr, rest, rest);
+    primitives_utils::take_car("caddar", pair_expr, rest, rest);
+    return rest;
+}
+shared_ptr<Expr> primitives::cadddr(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> pair_expr = nullptr;
+    primitives_utils::expect_1_arg("cadddr", args, pair_expr);
+    pair_expr = eval(context, pair_expr);
+    shared_ptr<Expr> rest = pair_expr;
+    primitives_utils::take_cdr("cadddr", pair_expr, rest, rest);
+    primitives_utils::take_cdr("cadddr", pair_expr, rest, rest);
+    primitives_utils::take_cdr("cadddr", pair_expr, rest, rest);
+    primitives_utils::take_car("cadddr", pair_expr, rest, rest);
+    return rest;
+}
+
 shared_ptr<Expr> primitives::cdr(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
 {
     shared_ptr<Expr> pair_expr = nullptr;
@@ -54,6 +208,167 @@ shared_ptr<Expr> primitives::cdr(const shared_ptr<Context>& context, shared_ptr<
     }
     return pair->cdr();
 }
+shared_ptr<Expr> primitives::cdar(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> pair_expr = nullptr;
+    primitives_utils::expect_1_arg("cdar", args, pair_expr);
+    pair_expr = eval(context, pair_expr);
+    shared_ptr<Expr> rest = pair_expr;
+    primitives_utils::take_car("cdar", pair_expr, rest, rest);
+    primitives_utils::take_cdr("cdar", pair_expr, rest, rest);
+    return rest;
+}
+shared_ptr<Expr> primitives::cdaar(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> pair_expr = nullptr;
+    primitives_utils::expect_1_arg("cdaar", args, pair_expr);
+    pair_expr = eval(context, pair_expr);
+    shared_ptr<Expr> rest = pair_expr;
+    primitives_utils::take_car("cdaar", pair_expr, rest, rest);
+    primitives_utils::take_car("cdaar", pair_expr, rest, rest);
+    primitives_utils::take_cdr("cdaar", pair_expr, rest, rest);
+    return rest;
+}
+shared_ptr<Expr> primitives::cdaaar(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> pair_expr = nullptr;
+    primitives_utils::expect_1_arg("cdaaar", args, pair_expr);
+    pair_expr = eval(context, pair_expr);
+    shared_ptr<Expr> rest = pair_expr;
+    primitives_utils::take_car("cdaaar", pair_expr, rest, rest);
+    primitives_utils::take_car("cdaaar", pair_expr, rest, rest);
+    primitives_utils::take_car("cdaaar", pair_expr, rest, rest);
+    primitives_utils::take_cdr("cdaaar", pair_expr, rest, rest);
+    return rest;
+}
+shared_ptr<Expr> primitives::cdaadr(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> pair_expr = nullptr;
+    primitives_utils::expect_1_arg("cdaadr", args, pair_expr);
+    pair_expr = eval(context, pair_expr);
+    shared_ptr<Expr> rest = pair_expr;
+    primitives_utils::take_cdr("cdaadr", pair_expr, rest, rest);
+    primitives_utils::take_car("cdaadr", pair_expr, rest, rest);
+    primitives_utils::take_car("cdaadr", pair_expr, rest, rest);
+    primitives_utils::take_cdr("cdaadr", pair_expr, rest, rest);
+    return rest;
+}
+shared_ptr<Expr> primitives::cdadr(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> pair_expr = nullptr;
+    primitives_utils::expect_1_arg("cdadr", args, pair_expr);
+    pair_expr = eval(context, pair_expr);
+    shared_ptr<Expr> rest = pair_expr;
+    primitives_utils::take_cdr("cdadr", pair_expr, rest, rest);
+    primitives_utils::take_car("cdadr", pair_expr, rest, rest);
+    primitives_utils::take_cdr("cdadr", pair_expr, rest, rest);
+    return rest;
+}
+shared_ptr<Expr> primitives::cdadar(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> pair_expr = nullptr;
+    primitives_utils::expect_1_arg("cdadar", args, pair_expr);
+    pair_expr = eval(context, pair_expr);
+    shared_ptr<Expr> rest = pair_expr;
+    primitives_utils::take_car("cdadar", pair_expr, rest, rest);
+    primitives_utils::take_cdr("cdadar", pair_expr, rest, rest);
+    primitives_utils::take_car("cdadar", pair_expr, rest, rest);
+    primitives_utils::take_cdr("cdadar", pair_expr, rest, rest);
+    return rest;
+}
+shared_ptr<Expr> primitives::cdaddr(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> pair_expr = nullptr;
+    primitives_utils::expect_1_arg("cdaddr", args, pair_expr);
+    pair_expr = eval(context, pair_expr);
+    shared_ptr<Expr> rest = pair_expr;
+    primitives_utils::take_cdr("cdaddr", pair_expr, rest, rest);
+    primitives_utils::take_cdr("cdaddr", pair_expr, rest, rest);
+    primitives_utils::take_car("cdaddr", pair_expr, rest, rest);
+    primitives_utils::take_cdr("cdaddr", pair_expr, rest, rest);
+    return rest;
+}
+shared_ptr<Expr> primitives::cddr(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> pair_expr = nullptr;
+    primitives_utils::expect_1_arg("cddr", args, pair_expr);
+    pair_expr = eval(context, pair_expr);
+    shared_ptr<Expr> rest = pair_expr;
+    primitives_utils::take_cdr("cddr", pair_expr, rest, rest);
+    primitives_utils::take_cdr("cddr", pair_expr, rest, rest);
+    return rest;
+}
+shared_ptr<Expr> primitives::cddar(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> pair_expr = nullptr;
+    primitives_utils::expect_1_arg("cddar", args, pair_expr);
+    pair_expr = eval(context, pair_expr);
+    shared_ptr<Expr> rest = pair_expr;
+    primitives_utils::take_car("cddar", pair_expr, rest, rest);
+    primitives_utils::take_cdr("cddar", pair_expr, rest, rest);
+    primitives_utils::take_cdr("cddar", pair_expr, rest, rest);
+    return rest;
+}
+shared_ptr<Expr> primitives::cddaar(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> pair_expr = nullptr;
+    primitives_utils::expect_1_arg("cddaar", args, pair_expr);
+    pair_expr = eval(context, pair_expr);
+    shared_ptr<Expr> rest = pair_expr;
+    primitives_utils::take_car("cddaar", pair_expr, rest, rest);
+    primitives_utils::take_car("cddaar", pair_expr, rest, rest);
+    primitives_utils::take_cdr("cddaar", pair_expr, rest, rest);
+    primitives_utils::take_cdr("cddaar", pair_expr, rest, rest);
+    return rest;
+}
+shared_ptr<Expr> primitives::cddadr(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> pair_expr = nullptr;
+    primitives_utils::expect_1_arg("cddadr", args, pair_expr);
+    pair_expr = eval(context, pair_expr);
+    shared_ptr<Expr> rest = pair_expr;
+    primitives_utils::take_cdr("cddadr", pair_expr, rest, rest);
+    primitives_utils::take_car("cddadr", pair_expr, rest, rest);
+    primitives_utils::take_cdr("cddadr", pair_expr, rest, rest);
+    primitives_utils::take_cdr("cddadr", pair_expr, rest, rest);
+    return rest;
+}
+shared_ptr<Expr> primitives::cdddr(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> pair_expr = nullptr;
+    primitives_utils::expect_1_arg("cdddr", args, pair_expr);
+    pair_expr = eval(context, pair_expr);
+    shared_ptr<Expr> rest = pair_expr;
+    primitives_utils::take_cdr("cdddr", pair_expr, rest, rest);
+    primitives_utils::take_cdr("cdddr", pair_expr, rest, rest);
+    primitives_utils::take_cdr("cdddr", pair_expr, rest, rest);
+    return rest;
+}
+shared_ptr<Expr> primitives::cdddar(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> pair_expr = nullptr;
+    primitives_utils::expect_1_arg("cdddar", args, pair_expr);
+    pair_expr = eval(context, pair_expr);
+    shared_ptr<Expr> rest = pair_expr;
+    primitives_utils::take_car("cdddar", pair_expr, rest, rest);
+    primitives_utils::take_cdr("cdddar", pair_expr, rest, rest);
+    primitives_utils::take_cdr("cdddar", pair_expr, rest, rest);
+    primitives_utils::take_cdr("cdddar", pair_expr, rest, rest);
+    return rest;
+}
+shared_ptr<Expr> primitives::cddddr(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> pair_expr = nullptr;
+    primitives_utils::expect_1_arg("cddddr", args, pair_expr);
+    pair_expr = eval(context, pair_expr);
+    shared_ptr<Expr> rest = pair_expr;
+    primitives_utils::take_cdr("cddddr", pair_expr, rest, rest);
+    primitives_utils::take_cdr("cddddr", pair_expr, rest, rest);
+    primitives_utils::take_cdr("cddddr", pair_expr, rest, rest);
+    primitives_utils::take_cdr("cddddr", pair_expr, rest, rest);
+    return rest;
+}
+
 shared_ptr<Expr> primitives::list(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
 {
     shared_ptr<Pair> list = nullptr;
@@ -77,4 +392,43 @@ shared_ptr<Expr> primitives::list(const shared_ptr<Context>& context, shared_ptr
     if (!list)
         return Expr::NIL;
     return Expr::make_pair(list);
+}
+
+//append
+shared_ptr<Expr> primitives::append(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Pair> result = nullptr;
+    shared_ptr<Pair> tail = nullptr;
+    for (auto list_expr : *args)
+    {
+        if (!list_expr) break;
+        const auto list = eval(context, std::move(list_expr));
+        if (list->is_nil())
+        {
+            continue;
+        }
+        if (!list->is_pair())
+        {
+            throw GlomError("append: argument is not a list: " + list->to_string());
+        }
+        auto current = list->as_pair()->begin();
+        while (*current != nullptr)
+        {
+            auto elem = std::move(*current++);
+            if (!result)
+            {
+                result = Pair::single(std::move(elem));
+                tail = result;
+            }
+            else
+            {
+                const auto new_tail = Pair::single(std::move(elem));
+                tail->set_cdr(Expr::make_pair(new_tail));
+                tail = new_tail;
+            }
+        }
+    }
+    if (!result)
+        return Expr::NIL;
+    return Expr::make_pair(result);
 }

--- a/src/primitives/list.cpp
+++ b/src/primitives/list.cpp
@@ -11,22 +11,22 @@ shared_ptr<Expr> primitives::is_null(const shared_ptr<Context>& context, shared_
 {
     shared_ptr<Expr> expr = nullptr;
     primitives_utils::expect_1_arg("null?", args, expr);
-    expr = context->eval(expr);
+    expr = eval(context, expr);
     return Expr::make_boolean(expr->is_nil());
 }
 shared_ptr<Expr> primitives::cons(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
 {
     shared_ptr<Expr> a, b = nullptr;
     primitives_utils::expect_2_args("cons", args, a, b);
-    a = context->eval(a);
-    b = context->eval(b);
+    a = eval(context, a);
+    b = eval(context, b);
     return Expr::make_pair(Pair::cons(a,b));
 }
 shared_ptr<Expr> primitives::car(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
 {
     shared_ptr<Expr> pair_expr = nullptr;
     primitives_utils::expect_1_arg("car", args, pair_expr);
-    pair_expr = context->eval(pair_expr);
+    pair_expr = eval(context, pair_expr);
     if (!pair_expr->is_pair())
     {
         throw GlomError("car: argument is not a pair");
@@ -42,7 +42,7 @@ shared_ptr<Expr> primitives::cdr(const shared_ptr<Context>& context, shared_ptr<
 {
     shared_ptr<Expr> pair_expr = nullptr;
     primitives_utils::expect_1_arg("car", args, pair_expr);
-    pair_expr = context->eval(pair_expr);
+    pair_expr = eval(context, pair_expr);
     if (!pair_expr->is_pair())
     {
         throw GlomError("cdr: argument is not a pair");
@@ -61,7 +61,7 @@ shared_ptr<Expr> primitives::list(const shared_ptr<Context>& context, shared_ptr
     for (auto elem_expr : *args)
     {
         if (!elem_expr) break;
-        auto last = context->eval(std::move(elem_expr));
+        auto last = eval(context, std::move(elem_expr));
         if (!list)
         {
             list = Pair::single(std::move(last));

--- a/src/primitives/logic_operation.cpp
+++ b/src/primitives/logic_operation.cpp
@@ -12,7 +12,7 @@ shared_ptr<Expr> primitives::logical_and(const shared_ptr<Context>& context, sha
     for (auto expr : *args)
     {
         if (!expr) break;
-        if (!context->eval(std::move(expr))->to_boolean())
+        if (!eval(context, std::move(expr))->to_boolean())
         {
             return Expr::FALSE;
         }
@@ -24,7 +24,7 @@ shared_ptr<Expr> primitives::logical_or(const shared_ptr<Context>& context, shar
     for (auto expr : *args)
     {
         if (!expr) break;
-        if (context->eval(std::move(expr))->to_boolean())
+        if (eval(context, std::move(expr))->to_boolean())
         {
             return Expr::TRUE;
         }
@@ -35,6 +35,6 @@ shared_ptr<Expr> primitives::logical_not(const shared_ptr<Context>& context, sha
 {
     shared_ptr<Expr> expr = nullptr;
     primitives_utils::expect_1_arg("not", args, expr);
-    expr = context->eval(expr);
+    expr = eval(context, expr);
     return Expr::make_boolean(!expr->to_boolean());
 }

--- a/src/primitives/math.cpp
+++ b/src/primitives/math.cpp
@@ -1,0 +1,360 @@
+//
+// Created by glom on 9/27/25.
+//
+#include <complex>
+
+#include "error.h"
+#include "expr.h"
+#include "context.h"
+#include "primitive.h"
+
+shared_ptr<Expr> primitives::exponentiation(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    if (args->empty() || !args->cdr()->is_nil())
+    {
+        throw GlomError("Invalid number of arguments exp: exactly one argument required");
+    }
+    const auto power_expr = eval(context, std::move(args->car()));
+    if (!power_expr->is_number())
+    {
+        throw GlomError("Invalid argument exp: " + power_expr->to_string() + " is not a number");
+    }
+    if (power_expr->is_number_int())
+    {
+        if (const auto power = power_expr->as_number_int(); power.is_zero())
+        {
+            return Expr::make_number_int(integer(0));
+        }
+    }
+    const auto power = power_expr->to_number_real();
+    const auto result = std::pow(M_E, power);
+    return Expr::make_number_real(result);
+}
+shared_ptr<Expr> primitives::logarithm(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    if (args->empty())
+    {
+        throw GlomError("Invalid number of arguments log: at least 1 argument required");
+    }
+    const auto arg_expr = eval(context, std::move(args->car()));
+    if (!arg_expr->is_number())
+    {
+        throw GlomError("Invalid argument log: " + arg_expr->to_string() + " is not a number");
+    }
+    if (arg_expr->is_number_int())
+    {
+        const auto arg = arg_expr->as_number_int();
+        if (arg.is_zero())
+        {
+            throw GlomError("Invalid argument log: logarithm of zero is undefined");
+        }
+        if (arg == integer(1))
+        {
+            return Expr::make_number_int(integer(0));
+        }
+    }
+    const auto arg = arg_expr->to_number_real();
+    if (arg <= 0)
+    {
+        throw GlomError("Invalid argument log: logarithm of non-positive number is undefined");
+    }
+    args = args->cdr()->as_pair();
+    shared_ptr<Expr> base_expr;
+    if (!args->empty())
+    {
+        base_expr = eval(context, std::move(args->car()));
+        if (!args->cdr()->is_nil())
+        {
+            throw GlomError("Invalid number of arguments log: at most 2 arguments allowed");
+        }
+        if (!base_expr->is_number())
+        {
+            throw GlomError("Invalid argument log: " + base_expr->to_string() + " is not a number");
+        }
+        if (base_expr->is_number_int())
+        {
+            if (const auto base = base_expr->as_number_int(); base.is_zero() || base == integer(1))
+            {
+                throw GlomError("Invalid argument log: logarithm base must be positive and not equal to 1");
+            }
+        }
+    }
+    else
+    {
+        base_expr = Expr::make_number_real(M_E);
+    }
+    const auto base = base_expr->to_number_real();
+    const auto result = std::log(arg) / std::log(base);
+    return Expr::make_number_real(result);
+}
+
+// sine
+shared_ptr<Expr> primitives::sine(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    if (args->empty() || !args->cdr()->is_nil())
+    {
+        throw GlomError("Invalid number of arguments sin: exactly one argument required");
+    }
+    const auto angle_expr = eval(context, std::move(args->car()));
+    if (!angle_expr->is_number())
+    {
+        throw GlomError("Invalid argument sin: " + angle_expr->to_string() + " is not a number");
+    }
+    if (angle_expr->is_number_int())
+    {
+        if (const auto angle = angle_expr->as_number_int(); angle.is_zero())
+        {
+            return Expr::make_number_int(integer(0));
+        }
+    }
+    const auto angle = angle_expr->to_number_real();
+    const auto result = std::sin(angle);
+    return Expr::make_number_real(result);
+}
+
+// cosine
+shared_ptr<Expr> primitives::cosine(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    if (args->empty() || !args->cdr()->is_nil())
+    {
+        throw GlomError("Invalid number of arguments cos: exactly one argument required");
+    }
+    const auto angle_expr = eval(context, std::move(args->car()));
+    if (!angle_expr->is_number())
+    {
+        throw GlomError("Invalid argument cos: " + angle_expr->to_string() + " is not a number");
+    }
+    if (angle_expr->is_number_int())
+    {
+        if (const auto angle = angle_expr->as_number_int(); angle.is_zero())
+        {
+            return Expr::make_number_int(integer(1));
+        }
+    }
+    const auto angle = angle_expr->to_number_real();
+    const auto result = std::cos(angle);
+    return Expr::make_number_real(result);
+}
+
+// tangent
+shared_ptr<Expr> primitives::tangent(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    if (args->empty() || !args->cdr()->is_nil())
+    {
+        throw GlomError("Invalid number of arguments tan: exactly one argument required");
+    }
+    const auto angle_expr = eval(context, std::move(args->car()));
+    if (!angle_expr->is_number())
+    {
+        throw GlomError("Invalid argument tan: " + angle_expr->to_string() + " is not a number");
+    }
+    if (angle_expr->is_number_int())
+    {
+        if (const auto angle = angle_expr->as_number_int(); angle.is_zero())
+        {
+            return Expr::make_number_int(integer(0));
+        }
+    }
+    const auto angle = angle_expr->to_number_real();
+    const auto result = std::tan(angle);
+    return Expr::make_number_real(result);
+}
+
+// arcsine
+shared_ptr<Expr> primitives::arcsine(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    if (args->empty() || !args->cdr()->is_nil())
+    {
+        throw GlomError("Invalid number of arguments asin: exactly one argument required");
+    }
+    const auto value_expr = eval(context, std::move(args->car()));
+    if (!value_expr->is_number())
+    {
+        throw GlomError("Invalid argument asin: " + value_expr->to_string() + " is not a number");
+    }
+    if (value_expr->is_number_int())
+    {
+        const auto value = value_expr->as_number_int();
+        if (value.is_zero())
+        {
+            return Expr::make_number_int(integer(0));
+        }
+        if (value == integer(1))
+        {
+            return Expr::make_number_real(M_PI / 2);
+        }
+        if (value == integer(-1))
+        {
+            return Expr::make_number_real(-M_PI / 2);
+        }
+    }
+    const auto value = value_expr->to_number_real();
+    if (value < -1 || value > 1)
+    {
+        throw GlomError("Invalid argument asin: arcsine is only defined for values in the range [-1, 1]");
+    }
+    const auto result = std::asin(value);
+    return Expr::make_number_real(result);
+}
+
+// arccosine
+shared_ptr<Expr> primitives::arccosine(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    if (args->empty() || !args->cdr()->is_nil())
+    {
+        throw GlomError("Invalid number of arguments acos: exactly one argument required");
+    }
+    const auto value_expr = eval(context, std::move(args->car()));
+    if (!value_expr->is_number())
+    {
+        throw GlomError("Invalid argument acos: " + value_expr->to_string() + " is not a number");
+    }
+    if (value_expr->is_number_int())
+    {
+        const auto value = value_expr->as_number_int();
+        if (value == integer(1))
+        {
+            return Expr::make_number_int(integer(0));
+        }
+        if (value == integer(0))
+        {
+            return Expr::make_number_real(M_PI / 2);
+        }
+        if (value == integer(-1))
+        {
+            return Expr::make_number_real(M_PI);
+        }
+    }
+    const auto value = value_expr->to_number_real();
+    if (value < -1 || value > 1)
+    {
+        throw GlomError("Invalid argument acos: arccosine is only defined for values in the range [-1, 1]");
+    }
+    const auto result = std::acos(value);
+    return Expr::make_number_real(result);
+}
+
+// arctangent
+shared_ptr<Expr> primitives::arctangent(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    if (args->empty())
+    {
+        throw GlomError("Invalid number of arguments atan: at least one argument required");
+    }
+    const auto y_expr = eval(context, std::move(args->car()));
+    if (!y_expr->is_number())
+    {
+        throw GlomError("Invalid argument atan: " + y_expr->to_string() + " is not a number");
+    }
+    if (y_expr->is_number_int())
+    {
+        if (const auto y = y_expr->as_number_int(); y.is_zero())
+        {
+            return Expr::make_number_int(integer(0));
+        }
+    }
+    const auto y = y_expr->to_number_real();
+    args = args->cdr()->as_pair();
+    shared_ptr<Expr> x_expr;
+    if (!args->empty())
+    {
+        x_expr = eval(context, std::move(args->car()));
+        if (!args->cdr()->is_nil())
+        {
+            throw GlomError("Invalid number of arguments atan: at most 2 arguments allowed");
+        }
+        if (!x_expr->is_number())
+        {
+            throw GlomError("Invalid argument atan: " + x_expr->to_string() + " is not a number");
+        }
+        if (x_expr->is_number_int())
+        {
+            if (const auto x = x_expr->as_number_int(); x.is_zero())
+            {
+                if (y > 0)
+                {
+                    return Expr::make_number_real(M_PI / 2);
+                }
+                return Expr::make_number_real(-M_PI / 2);
+            }
+        }
+    }
+    else
+    {
+        x_expr = Expr::make_number_int(integer(1));
+    }
+    const auto x = x_expr->to_number_real();
+    const auto result = std::atan2(y, x);
+    return Expr::make_number_real(result);
+}
+
+// square root
+shared_ptr<Expr> primitives::square_root(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    if (args->empty() || !args->cdr()->is_nil())
+    {
+        throw GlomError("Invalid number of arguments sqrt: exactly one argument required");
+    }
+    const auto value_expr = eval(context, std::move(args->car()));
+    if (!value_expr->is_number())
+    {
+        throw GlomError("Invalid argument sqrt: " + value_expr->to_string() + " is not a number");
+    }
+    if (value_expr->is_number_int())
+    {
+        const auto value = value_expr->as_number_int();
+        if (value.is_negative())
+        {
+            throw GlomError("Invalid argument sqrt: cannot compute square root of negative integer");
+        }
+        const auto result = value.sqrt();
+        if (result.index() == 0)
+        {
+            return Expr::make_number_int(std::get<0>(result));
+        }
+        return Expr::make_number_real(std::get<1>(result));
+    }
+    if (value_expr->is_number_rat())
+    {
+        const auto value = value_expr->as_number_rat();
+        if (value.is_negative())
+        {
+            throw GlomError("Invalid argument sqrt: cannot compute square root of negative rational number");
+        }
+        const auto numerator_sqrt = value.numerator().sqrt();
+        const auto denominator_sqrt = value.denominator().sqrt();
+        if (numerator_sqrt.index() == 0 && denominator_sqrt.index() == 0)
+        {
+            return Expr::make_number_rat(rational(std::get<0>(numerator_sqrt),std::get<0>(denominator_sqrt)));
+        }
+        const auto real_numerator = numerator_sqrt.index() == 0 ? std::get<0>(numerator_sqrt).to_real() : std::get<1>(numerator_sqrt);
+        const auto real_denominator = denominator_sqrt.index() == 0 ? std::get<0>(denominator_sqrt).to_real() : std::get<1>(denominator_sqrt);
+        return Expr::make_number_real(real_numerator / real_denominator);
+    }
+    const auto value = value_expr->as_number_real();
+    if (value < 0)
+    {
+        throw GlomError("Invalid argument sqrt: cannot compute square root of negative real number");
+    }
+    const auto result = std::sqrt(value);
+    return Expr::make_number_real(result);
+}
+
+shared_ptr<Expr> primitives::square_root_integer(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    if (args->empty() || !args->cdr()->is_nil())
+    {
+        throw GlomError("Invalid number of arguments isqrt: exactly one argument required");
+    }
+    const auto value_expr = eval(context, std::move(args->car()));
+    if (!value_expr->is_number_int())
+    {
+        throw GlomError("Invalid argument isqrt: " + value_expr->to_string() + " is not a integer");
+    }
+    const auto value = value_expr->as_number_int();
+    if (value.is_negative())
+    {
+        throw GlomError("Invalid argument isqrt: cannot compute square root of negative integer");
+    }
+    return Expr::make_number_int(value.isqrt());
+}

--- a/src/primitives/new_bindings.cpp
+++ b/src/primitives/new_bindings.cpp
@@ -154,3 +154,66 @@ shared_ptr<Expr> primitives::let(const shared_ptr<Context>& context, shared_ptr<
     const auto apply = Pair::cons(std::move(lambda), Expr::make_pair(lambda_args));
     return eval(context, Expr::make_pair(apply));
 }
+
+shared_ptr<Expr> primitives::let_star(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    if (args->empty() || args->cdr()->is_nil())
+    {
+        throw GlomError("Invalid number of arguments let*");
+    }
+    shared_ptr<Pair> current = std::move(args);
+    const shared_ptr<Expr> bindings_expr = current->car();
+    current = current->cdr()->as_pair();
+    if (!bindings_expr->is_pair())
+    {
+        throw GlomError("Invalid bindings in let*");
+    }
+    const auto bindings_list = bindings_expr->as_pair();
+    auto lambda_params = vector<Param>();
+    shared_ptr<Pair> lambda_args = nullptr;
+    shared_ptr<Context> lambda_context = Context::new_context(context);
+    for (shared_ptr<Pair> lambda_args_tail = nullptr; const auto& binding_expr : *bindings_list)
+    {
+        if (!binding_expr) break;
+        if (!binding_expr->is_pair())
+        {
+            throw GlomError("Invalid binding in let*");
+        }
+        const auto binding = binding_expr->as_pair();
+        if (binding->empty() || binding->cdr()->is_nil())
+        {
+            throw GlomError("Invalid binding in let");
+        }
+        const auto name_expr = binding->car();
+        const auto rest = binding->cdr()->as_pair();
+        if (!name_expr->is_symbol())
+        {
+            throw GlomError("Invalid binding name in let, must be symbol");
+        }
+        if (!rest->cdr()->is_nil())
+        {
+            throw GlomError("Invalid binding in let, must have exactly one value");
+        }
+        const auto binding_name = name_expr->as_symbol();
+        auto lambda_param = Param(binding_name, false);
+        shared_ptr<Expr> lambda_arg = eval(lambda_context, std::move(rest->car()));
+        lambda_params.emplace_back(lambda_param);
+        lambda_context->add(binding_name, lambda_arg);
+        const auto new_tail = Pair::single(std::move(lambda_arg));
+        if (!lambda_args)
+        {
+            lambda_args = new_tail;
+            lambda_args_tail = lambda_args;
+        }
+        else
+        {
+            lambda_args_tail->set_cdr(Expr::make_pair(new_tail));
+            lambda_args_tail = new_tail;
+        }
+    }
+    auto body = current;
+    auto lambda = Expr::make_lambda(make_shared<Lambda>(std::move(lambda_params), std::move(body), lambda_context));
+
+    const auto apply = Pair::cons(std::move(lambda), Expr::make_pair(lambda_args));
+    return eval(context, Expr::make_pair(apply));
+}

--- a/src/primitives/new_bindings.cpp
+++ b/src/primitives/new_bindings.cpp
@@ -27,7 +27,7 @@ shared_ptr<Expr> primitives::define(const shared_ptr<Context>& context, shared_p
             name = name_params_expr->as_symbol();
             auto value_expr = std::move(current->car());
             current = current->cdr()->as_pair();
-            value = context->eval(std::move(value_expr));;
+            value = eval(context, std::move(value_expr));;
             if (!current->empty())
             {
                 throw GlomError("Invalid body define");
@@ -130,7 +130,7 @@ shared_ptr<Expr> primitives::let(const shared_ptr<Context>& context, shared_ptr<
         }
         const auto binding_name = name_expr->as_symbol();
         auto lambda_param = Param(binding_name, false);
-        shared_ptr<Expr> lambda_arg = context->eval(std::move(rest->car()));
+        shared_ptr<Expr> lambda_arg = eval(context, std::move(rest->car()));
         lambda_params.emplace_back(lambda_param);
         const auto new_tail = Pair::single(std::move(lambda_arg));
         if (!lambda_args)
@@ -152,5 +152,5 @@ shared_ptr<Expr> primitives::let(const shared_ptr<Context>& context, shared_ptr<
         lambda_context->add(name->as_symbol(), lambda);
     }
     const auto apply = Pair::cons(std::move(lambda), Expr::make_pair(lambda_args));
-    return context->eval(Expr::make_pair(apply));
+    return eval(context, Expr::make_pair(apply));
 }

--- a/src/primitives/new_bindings.cpp
+++ b/src/primitives/new_bindings.cpp
@@ -130,7 +130,7 @@ shared_ptr<Expr> primitives::let(const shared_ptr<Context>& context, shared_ptr<
         }
         const auto binding_name = name_expr->as_symbol();
         auto lambda_param = Param(binding_name, false);
-        shared_ptr<Expr> lambda_arg = eval(context, std::move(rest->car()));
+        shared_ptr<Expr> lambda_arg = std::move(rest->car());
         lambda_params.emplace_back(lambda_param);
         const auto new_tail = Pair::single(std::move(lambda_arg));
         if (!lambda_args)

--- a/src/primitives/number_comparator.cpp
+++ b/src/primitives/number_comparator.cpp
@@ -6,11 +6,6 @@
 #include "context.h"
 #include "primitive.h"
 
-shared_ptr<Expr> primitives_utils::continuation(const shared_ptr<Context>& context, shared_ptr<Pair>&& exprs)
-{
-    return Expr::make_cont(std::make_unique<Continuation>(context, std::move(exprs)));
-}
-
 bool primitives_utils::generic_num_eq(shared_ptr<Expr>& a, shared_ptr<Expr>& b)
 {
     coerce_number(a,b);

--- a/src/primitives/number_comparator.cpp
+++ b/src/primitives/number_comparator.cpp
@@ -20,9 +20,9 @@ bool primitives_utils::generic_num_eq(shared_ptr<Expr>& a, shared_ptr<Expr>& b)
     return a->as_number_int() == b->as_number_int();
 }
 
-bool generic_lt(shared_ptr<Expr>& a, shared_ptr<Expr>& b)
+bool primitives_utils::generic_num_lt(shared_ptr<Expr>& a, shared_ptr<Expr>& b)
 {
-    primitives_utils::coerce_number(a,b);
+    coerce_number(a,b);
     if (a->is_number_real())
     {
         return a->as_number_real() < b->as_number_real();
@@ -34,9 +34,9 @@ bool generic_lt(shared_ptr<Expr>& a, shared_ptr<Expr>& b)
     return a->as_number_int() < b->as_number_int();
 }
 
-bool generic_gt(shared_ptr<Expr>& a, shared_ptr<Expr>& b)
+bool primitives_utils::generic_num_gt(shared_ptr<Expr>& a, shared_ptr<Expr>& b)
 {
-    primitives_utils::coerce_number(a,b);
+    coerce_number(a,b);
     if (a->is_number_real())
     {
         return a->as_number_real() > b->as_number_real();
@@ -186,7 +186,7 @@ shared_ptr<Expr> primitives::le(const shared_ptr<Context>& context, shared_ptr<P
         {
             throw GlomError("Invalid argument <=: " + next_expr->to_string() + " is not a number");
         }
-        if (generic_gt(last, next_expr))
+        if (primitives_utils::generic_num_gt(last, next_expr))
         {
             return Expr::FALSE;
         }
@@ -216,7 +216,7 @@ shared_ptr<Expr> primitives::ge(const shared_ptr<Context>& context, shared_ptr<P
         {
             throw GlomError("Invalid argument >=: " + next_expr->to_string() + " is not a number");
         }
-        if (generic_lt(last, next_expr))
+        if (primitives_utils::generic_num_lt(last, next_expr))
         {
             return Expr::FALSE;
         }

--- a/src/primitives/number_comparator.cpp
+++ b/src/primitives/number_comparator.cpp
@@ -6,6 +6,11 @@
 #include "context.h"
 #include "primitive.h"
 
+shared_ptr<Expr> primitives_utils::continuation(const shared_ptr<Context>& context, shared_ptr<Pair>&& exprs)
+{
+    return Expr::make_cont(std::make_unique<Continuation>(context, std::move(exprs)));
+}
+
 bool primitives_utils::generic_num_eq(shared_ptr<Expr>& a, shared_ptr<Expr>& b)
 {
     coerce_number(a,b);
@@ -82,7 +87,7 @@ shared_ptr<Expr> primitives::eq(const shared_ptr<Context>& context, shared_ptr<P
     {
         throw GlomError("Invalid number of arguments =: at least two arguments required");
     }
-    const auto first_expr = context->eval(std::move(args->car()));
+    const auto first_expr = eval(context, std::move(args->car()));
     if (!first_expr->is_number())
     {
         throw GlomError("Invalid argument =: " + first_expr->to_string() + " is not a number");
@@ -92,7 +97,7 @@ shared_ptr<Expr> primitives::eq(const shared_ptr<Context>& context, shared_ptr<P
     for (const auto it: *rest)
     {
         if (!it) break;
-        auto next_expr = context->eval(it);
+        auto next_expr = eval(context, it);
         if (!next_expr->is_number())
         {
             throw GlomError("Invalid argument =: " + next_expr->to_string() + " is not a number");
@@ -110,7 +115,7 @@ shared_ptr<Expr> primitives::lt(const shared_ptr<Context>& context, shared_ptr<P
     {
         throw GlomError("Invalid number of arguments <: at least two arguments required");
     }
-    const auto first = context->eval(std::move(args->car()));
+    const auto first = eval(context, std::move(args->car()));
     if (!first->is_number())
     {
         throw GlomError("Invalid argument <: " + first->to_string() + " is not a number");
@@ -120,7 +125,7 @@ shared_ptr<Expr> primitives::lt(const shared_ptr<Context>& context, shared_ptr<P
     for (const auto it: *rest)
     {
         if (!it) break;
-        auto next_expr = context->eval(it);
+        auto next_expr = eval(context, it);
         if (!next_expr->is_number())
         {
             throw GlomError("Invalid argument <: " + next_expr->to_string() + " is not a number");
@@ -139,7 +144,7 @@ shared_ptr<Expr> primitives::gt(const shared_ptr<Context>& context, shared_ptr<P
     {
         throw GlomError("Invalid number of arguments >: at least two arguments required");
     }
-    const auto first = context->eval(std::move(args->car()));
+    const auto first = eval(context, std::move(args->car()));
     if (!first->is_number())
     {
         throw GlomError("Invalid argument >: " + first->to_string() + " is not a number");
@@ -149,7 +154,7 @@ shared_ptr<Expr> primitives::gt(const shared_ptr<Context>& context, shared_ptr<P
     for (const auto it: *rest)
     {
         if (!it) break;
-         auto next_expr = context->eval(it);
+         auto next_expr = eval(context, it);
 
         if (!next_expr->is_number())
         {
@@ -170,7 +175,7 @@ shared_ptr<Expr> primitives::le(const shared_ptr<Context>& context, shared_ptr<P
     {
         throw GlomError("Invalid number of arguments <=: at least two arguments required");
     }
-    const auto first = context->eval(std::move(args->car()));
+    const auto first = eval(context, std::move(args->car()));
     if (!first->is_number())
     {
         throw GlomError("Invalid argument <=: " + first->to_string() + " is not a number");
@@ -180,7 +185,7 @@ shared_ptr<Expr> primitives::le(const shared_ptr<Context>& context, shared_ptr<P
     for (const auto it: *rest)
     {
         if (!it) break;
-        auto next_expr = context->eval(it);
+        auto next_expr = eval(context, it);
 
         if (!next_expr->is_number())
         {
@@ -200,7 +205,7 @@ shared_ptr<Expr> primitives::ge(const shared_ptr<Context>& context, shared_ptr<P
     {
         throw GlomError("Invalid number of arguments >=: at least two arguments required");
     }
-    const auto first = context->eval(std::move(args->car()));
+    const auto first = eval(context, std::move(args->car()));
     if (!first->is_number())
     {
         throw GlomError("Invalid argument >=: " + first->to_string() + " is not a number");
@@ -210,7 +215,7 @@ shared_ptr<Expr> primitives::ge(const shared_ptr<Context>& context, shared_ptr<P
     for (const auto it: *rest)
     {
         if (!it) break;
-        auto next_expr = context->eval(it);
+        auto next_expr = eval(context, it);
 
         if (!next_expr->is_number())
         {

--- a/src/primitives/number_operation.cpp
+++ b/src/primitives/number_operation.cpp
@@ -158,7 +158,7 @@ shared_ptr<Expr> primitives::add(const shared_ptr<Context>& context, shared_ptr<
     for (auto expr : *args)
     {
         if (!expr) break;
-        auto arg = context->eval(std::move(expr));
+        auto arg = eval(context, std::move(expr));
         if (!arg->is_number())
         {
             throw GlomError("Invalid argument +: " + arg->to_string());
@@ -178,7 +178,7 @@ shared_ptr<Expr> primitives::sub(const shared_ptr<Context>& context, shared_ptr<
     {
         throw GlomError("Invalid number of arguments -: at least one argument required");
     }
-    const auto minuend_expr = context->eval(args->car());
+    const auto minuend_expr = eval(context, args->car());
     if (!minuend_expr->is_number())
     {
         throw GlomError("Invalid argument -: " + minuend_expr->to_string());
@@ -191,7 +191,7 @@ shared_ptr<Expr> primitives::sub(const shared_ptr<Context>& context, shared_ptr<
     for (const auto subtrahends = args->cdr()->as_pair(); auto expr : *subtrahends)
     {
         if (!expr) break;
-        auto arg = context->eval(std::move(expr));
+        auto arg = eval(context, std::move(expr));
         if (!arg->is_number())
         {
             throw GlomError("Invalid argument -: " + arg->to_string());
@@ -211,7 +211,7 @@ shared_ptr<Expr> primitives::mul(const shared_ptr<Context>& context, shared_ptr<
     for (auto expr : *args)
     {
         if (!expr) break;
-        auto arg = context->eval(std::move(expr));
+        auto arg = eval(context, std::move(expr));
         if (!arg->is_number())
         {
             throw GlomError("Invalid argument *: " + arg->to_string());
@@ -231,7 +231,7 @@ shared_ptr<Expr> primitives::div(const shared_ptr<Context>& context, shared_ptr<
     {
         throw GlomError("Invalid number of arguments /: at least one argument required");
     }
-    const auto dividend_expr = context->eval(args->car());
+    const auto dividend_expr = eval(context, args->car());
     if (!dividend_expr->is_number())
     {
         throw GlomError("Invalid argument /: " + dividend_expr->to_string());
@@ -244,7 +244,7 @@ shared_ptr<Expr> primitives::div(const shared_ptr<Context>& context, shared_ptr<
     for (const auto divisors = args->cdr()->as_pair(); auto expr : *divisors)
     {
         if (!expr) break;
-        auto arg = context->eval(std::move(expr));
+        auto arg = eval(context, std::move(expr));
         if (!arg->is_number())
         {
             throw GlomError("Invalid argument /: " + arg->to_string());
@@ -259,8 +259,8 @@ shared_ptr<Expr> primitives::remainder(const shared_ptr<Context>& context, share
 {
     shared_ptr<Expr> a,b = nullptr;
     primitives_utils::expect_2_args("remainder", args, a, b);
-    a = context->eval(std::move(a));
-    b = context->eval(std::move(b));
+    a = eval(context, std::move(a));
+    b = eval(context, std::move(b));
 
     if (!a->is_number_int() || !b->is_number_int())
     {
@@ -280,8 +280,8 @@ shared_ptr<Expr> primitives::modulo(const shared_ptr<Context>& context, shared_p
 {
     shared_ptr<Expr> a,b = nullptr;
     primitives_utils::expect_2_args("modulo", args, a, b);
-    a = context->eval(std::move(a));
-    b = context->eval(std::move(b));
+    a = eval(context, std::move(a));
+    b = eval(context, std::move(b));
 
     if (!a->is_number_int() || !b->is_number_int())
     {
@@ -302,8 +302,8 @@ shared_ptr<Expr> primitives::power(const shared_ptr<Context>& context, shared_pt
 {
     shared_ptr<Expr> base_expr, exp_expr = nullptr;
     primitives_utils::expect_2_args("expt", args, base_expr, exp_expr);
-    base_expr = context->eval(std::move(base_expr));
-    exp_expr = context->eval(std::move(exp_expr));
+    base_expr = eval(context, std::move(base_expr));
+    exp_expr = eval(context, std::move(exp_expr));
     if (!base_expr->is_number() || !exp_expr->is_number())
     {
         throw GlomError("Invalid argument expt: both arguments must be numbers");

--- a/src/primitives/number_operation.cpp
+++ b/src/primitives/number_operation.cpp
@@ -255,6 +255,27 @@ shared_ptr<Expr> primitives::div(const shared_ptr<Context>& context, shared_ptr<
     return dividend;
 }
 
+shared_ptr<Expr> primitives::quotient(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> a,b = nullptr;
+    primitives_utils::expect_2_args("quotient", args, a, b);
+    a = eval(context, std::move(a));
+    b = eval(context, std::move(b));
+
+    if (!a->is_number_int() || !b->is_number_int())
+    {
+        throw GlomError("quotient only support integer numbers");
+    }
+    const integer dividend = a->as_number_int();
+    const integer divisor = b->as_number_int();
+    if (divisor.is_zero())
+    {
+        throw GlomError("quotient undefined for 0");
+    }
+    integer result = dividend / divisor;
+    return Expr::make_number_int(std::move(result));
+}
+
 shared_ptr<Expr> primitives::remainder(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
 {
     shared_ptr<Expr> a,b = nullptr;
@@ -298,7 +319,7 @@ shared_ptr<Expr> primitives::modulo(const shared_ptr<Context>& context, shared_p
 }
 
 
-shared_ptr<Expr> primitives::power(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+shared_ptr<Expr> primitives::exponential(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
 {
     shared_ptr<Expr> base_expr, exp_expr = nullptr;
     primitives_utils::expect_2_args("expt", args, base_expr, exp_expr);

--- a/src/primitives/number_utils.cpp
+++ b/src/primitives/number_utils.cpp
@@ -1,0 +1,437 @@
+//
+// Created by glom on 9/27/25.
+//
+#include <cmath>
+
+#include "error.h"
+#include "expr.h"
+#include "context.h"
+#include "primitive.h"
+
+//is_zero
+shared_ptr<Expr> primitives::is_zero(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    if (args->empty() || !args->cdr()->is_nil())
+    {
+        throw GlomError("Invalid number of arguments zero?: exactly one argument required");
+    }
+    const auto expr = eval(context, std::move(args->car()));
+    if (!expr->is_number())
+    {
+        throw GlomError("Invalid argument zero?: " + expr->to_string() + " is not a number");
+    }
+    if (expr->is_number_int())
+    {
+        return Expr::make_boolean(expr->as_number_int().is_zero());
+    }
+    if (expr->is_number_rat())
+    {
+        return Expr::make_boolean(expr->as_number_rat().is_zero());
+    }
+    return Expr::make_boolean(expr->as_number_real() == 0);
+}
+
+// positive?
+shared_ptr<Expr> primitives::is_positive(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    if (args->empty() || !args->cdr()->is_nil())
+    {
+        throw GlomError("Invalid number of arguments positive?: exactly one argument required");
+    }
+    const auto expr = eval(context, std::move(args->car()));
+    if (!expr->is_number())
+    {
+        throw GlomError("Invalid argument positive?: " + expr->to_string() + " is not a number");
+    }
+    if (expr->is_number_int())
+    {
+        return Expr::make_boolean(expr->as_number_int().is_positive());
+    }
+    if (expr->is_number_rat())
+    {
+        return Expr::make_boolean(expr->as_number_rat().is_positive());
+    }
+    return Expr::make_boolean(expr->as_number_real() > 0);
+}
+
+// negative?
+shared_ptr<Expr> primitives::is_negative(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    if (args->empty() || !args->cdr()->is_nil())
+    {
+        throw GlomError("Invalid number of arguments negative?: exactly one argument required");
+    }
+    const auto expr = eval(context, std::move(args->car()));
+    if (!expr->is_number())
+    {
+        throw GlomError("Invalid argument negative?: " + expr->to_string() + " is not a number");
+    }
+    if (expr->is_number_int())
+    {
+        return Expr::make_boolean(expr->as_number_int().is_negative());
+    }
+    if (expr->is_number_rat())
+    {
+        return Expr::make_boolean(expr->as_number_rat().is_negative());
+    }
+    return Expr::make_boolean(expr->as_number_real() < 0);
+}
+
+// even?
+shared_ptr<Expr> primitives::is_even(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    if (args->empty() || !args->cdr()->is_nil())
+    {
+        throw GlomError("Invalid number of arguments even?: exactly one argument required");
+    }
+    const auto expr = eval(context, std::move(args->car()));
+    if (!expr->is_number())
+    {
+        throw GlomError("Invalid argument even?: " + expr->to_string() + " is not a number");
+    }
+    if (expr->is_number_int())
+    {
+        return Expr::make_boolean(expr->as_number_int().remainder(integer(2)).is_zero());
+    }
+    if (expr->is_number_rat())
+    {
+        const auto rat = expr->as_number_rat();
+        if (!rat.den.is_one())
+        {
+            return Expr::FALSE;
+        }
+        return Expr::make_boolean(rat.num.remainder(integer(2)).is_zero());
+    }
+    const auto real_val = expr->as_number_real();
+    if (std::floor(real_val) != real_val)
+    {
+        return Expr::FALSE;
+    }
+    return Expr::make_boolean(static_cast<int64_t>(real_val) % 2 == 0);
+}
+
+// odd?
+shared_ptr<Expr> primitives::is_odd(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    if (args->empty() || !args->cdr()->is_nil())
+    {
+        throw GlomError("Invalid number of arguments odd?: exactly one argument required");
+    }
+    const auto expr = eval(context, std::move(args->car()));
+    if (!expr->is_number())
+    {
+        throw GlomError("Invalid argument odd?: " + expr->to_string() + " is not a number");
+    }
+    if (expr->is_number_int())
+    {
+        return Expr::make_boolean(!expr->as_number_int().remainder(integer(2)).is_zero());
+    }
+    if (expr->is_number_rat())
+    {
+        const auto rat = expr->as_number_rat();
+        if (!rat.den.is_one())
+        {
+            return Expr::FALSE;
+        }
+        return Expr::make_boolean(!rat.num.remainder(integer(2)).is_zero());
+    }
+    const auto real_val = expr->as_number_real();
+    if (std::floor(real_val) != real_val)
+    {
+        return Expr::FALSE;
+    }
+    return Expr::make_boolean(static_cast<int64_t>(real_val) % 2 != 0);
+}
+
+// max
+shared_ptr<Expr> primitives::max(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    if (args->empty())
+    {
+        throw GlomError("Invalid number of arguments max: at least one argument required");
+    }
+    const auto first_expr = eval(context, std::move(args->car()));
+    if (!first_expr->is_number())
+    {
+        throw GlomError("Invalid argument max: " + first_expr->to_string() + " is not a number");
+    }
+    const auto rest = args->cdr()->as_pair();
+    auto first = first_expr;
+    for (const auto it: *rest)
+    {
+        if (!it) break;
+        auto next_expr = eval(context, it);
+        if (!next_expr->is_number())
+        {
+            throw GlomError("Invalid argument max: " + next_expr->to_string() + " is not a number");
+        }
+        if (primitives_utils::generic_num_gt(next_expr,first))
+        {
+            first = next_expr;
+        }
+    }
+    return first;
+}
+
+// min
+shared_ptr<Expr> primitives::min(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    if (args->empty())
+    {
+        throw GlomError("Invalid number of arguments min: at least one argument required");
+    }
+    const auto first_expr = eval(context, std::move(args->car()));
+    if (!first_expr->is_number())
+    {
+        throw GlomError("Invalid argument min: " + first_expr->to_string() + " is not a number");
+    }
+    const auto rest = args->cdr()->as_pair();
+    auto first = first_expr;
+    for (const auto it: *rest)
+    {
+        if (!it) break;
+        auto next_expr = eval(context, it);
+        if (!next_expr->is_number())
+        {
+            throw GlomError("Invalid argument min: " + next_expr->to_string() + " is not a number");
+        }
+        if (primitives_utils::generic_num_lt(next_expr,first))
+        {
+            first = next_expr;
+        }
+    }
+    return first;
+}
+
+// abs
+shared_ptr<Expr> primitives::abs(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    if (args->empty() || !args->cdr()->is_nil())
+    {
+        throw GlomError("Invalid number of arguments abs: exactly one argument required");
+    }
+    const auto expr = eval(context, std::move(args->car()));
+    if (!expr->is_number())
+    {
+        throw GlomError("Invalid argument abs: " + expr->to_string() + " is not a number");
+    }
+    if (expr->is_number_int())
+    {
+        return Expr::make_number_int(expr->as_number_int().abs());
+    }
+    if (expr->is_number_rat())
+    {
+        return Expr::make_number_rat(expr->as_number_rat().abs());
+    }
+    return Expr::make_number_real(std::fabs(expr->as_number_real()));
+}
+
+// gcd
+shared_ptr<Expr> primitives::gcd(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    if (args->empty())
+    {
+        throw GlomError("Invalid number of arguments gcd: at least one argument required");
+    }
+    const auto first_expr = eval(context, std::move(args->car()));
+    if (!first_expr->is_number_int())
+    {
+        throw GlomError("Invalid argument gcd: " + first_expr->to_string() + " is not an integer");
+    }
+    const auto rest = args->cdr()->as_pair();
+    auto result = first_expr->as_number_int().abs();
+    for (const auto it: *rest)
+    {
+        if (!it) break;
+        const auto next_expr = eval(context, it);
+        if (!next_expr->is_number_int())
+        {
+            throw GlomError("Invalid argument gcd: " + next_expr->to_string() + " is not an integer");
+        }
+        const auto common = rational::gcd(result, next_expr->as_number_int().abs());
+        result = common;
+    }
+    return Expr::make_number_int(result);
+}
+
+// lcm
+shared_ptr<Expr> primitives::lcm(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    if (args->empty())
+    {
+        throw GlomError("Invalid number of arguments lcm: at least one argument required");
+    }
+    const auto first_expr = eval(context, std::move(args->car()));
+    if (!first_expr->is_number_int())
+    {
+        throw GlomError("Invalid argument lcm: " + first_expr->to_string() + " is not an integer");
+    }
+    const auto rest = args->cdr()->as_pair();
+    auto result = first_expr->as_number_int().abs();
+    for (const auto it: *rest)
+    {
+        if (!it) break;
+        const auto next_expr = eval(context, it);
+        if (!next_expr->is_number_int())
+        {
+            throw GlomError("Invalid argument lcm: " + next_expr->to_string() + " is not an integer");
+        }
+        if (result.is_zero() || next_expr->as_number_int().is_zero())
+        {
+            result = integer(0);
+        }
+        else
+        {
+            const auto common = rational::gcd(result, next_expr->as_number_int().abs());
+            result = result / common * next_expr->as_number_int().abs();
+        }
+    }
+    return Expr::make_number_int(result);
+}
+
+// floor
+shared_ptr<Expr> primitives::floor(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    if (args->empty() || !args->cdr()->is_nil())
+    {
+        throw GlomError("Invalid number of arguments abs: exactly one argument required");
+    }
+    const auto expr = eval(context, std::move(args->car()));
+    if (!expr->is_number())
+    {
+        throw GlomError("Invalid argument abs: " + expr->to_string() + " is not a number");
+    }
+    integer result;
+    if (expr->is_number_int())
+    {
+       result = expr->as_number_int().abs();
+    }
+    else if (expr->is_number_rat())
+    {
+        result = expr->as_number_rat().to_integer();
+    }
+    else
+    {
+        return Expr::make_number_real(std::floor(expr->as_number_real()));
+    }
+    return Expr::make_number_int(result);
+}
+
+//ceiling
+shared_ptr<Expr> primitives::ceiling(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    if (args->empty() || !args->cdr()->is_nil())
+    {
+        throw GlomError("Invalid number of arguments ceiling: exactly one argument required");
+    }
+    const auto expr = eval(context, std::move(args->car()));
+    if (!expr->is_number())
+    {
+        throw GlomError("Invalid argument ceiling: " + expr->to_string() + " is not a number");
+    }
+    integer result;
+    if (expr->is_number_int())
+    {
+       result = expr->as_number_int().abs();
+    }
+    else if (expr->is_number_rat())
+    {
+        result = expr->as_number_rat().to_integer();
+        if (!expr->as_number_rat().is_integer() && expr->as_number_rat().is_positive())
+        {
+            result = result + integer(1);
+        }
+    }
+    else
+    {
+        return Expr::make_number_real(std::ceil(expr->as_number_real()));
+    }
+    return Expr::make_number_int(result);
+}
+
+// truncate
+shared_ptr<Expr> primitives::truncate(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    if (args->empty() || !args->cdr()->is_nil())
+    {
+        throw GlomError("Invalid number of arguments truncate: exactly one argument required");
+    }
+    const auto expr = eval(context, std::move(args->car()));
+    if (!expr->is_number())
+    {
+        throw GlomError("Invalid argument truncate: " + expr->to_string() + " is not a number");
+    }
+    integer result;
+    if (expr->is_number_int())
+    {
+        result = expr->as_number_int().abs();
+    }
+    else if (expr->is_number_rat())
+    {
+        result = expr->as_number_rat().to_integer();
+    }
+    else
+    {
+       return Expr::make_number_real(expr->as_number_real() > 0 ? std::floor(expr->as_number_real()) : std::ceil(expr->as_number_real()));
+    }
+    return Expr::make_number_int(result);
+}
+
+//round
+shared_ptr<Expr> primitives::round(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    if (args->empty() || !args->cdr()->is_nil())
+    {
+        throw GlomError("Invalid number of arguments round: exactly one argument required");
+    }
+    const auto expr = eval(context, std::move(args->car()));
+    if (!expr->is_number())
+    {
+        throw GlomError("Invalid argument round: " + expr->to_string() + " is not a number");
+    }
+    integer result;
+    if (expr->is_number_int())
+    {
+        result = expr->as_number_int().abs();
+    }
+    else if (expr->is_number_rat())
+    {
+        const auto rat = expr->as_number_rat();
+        const auto integer_part = rat.to_integer();
+        if (const rational fractional_part = rat - rational(integer_part); fractional_part.is_zero())
+        {
+            result = integer_part;
+        }
+        else
+        {
+            const auto half = rational(1, 2);
+            if (fractional_part.is_positive())
+            {
+                if (fractional_part >= half)
+                {
+                    result = integer_part + integer(1);
+                }
+                else
+                {
+                    result = integer_part;
+                }
+            }
+            else
+            {
+                if (fractional_part <= -half)
+                {
+                    result = integer_part - integer(1);
+                }
+                else
+                {
+                    result = integer_part;
+                }
+            }
+        }
+    }
+    else
+    {
+        return Expr::make_number_real(std::round(expr->as_number_real()));
+    }
+    return Expr::make_number_int(result);
+}

--- a/src/primitives/type.cpp
+++ b/src/primitives/type.cpp
@@ -193,3 +193,67 @@ shared_ptr<Expr> primitives::string_to_symbol(const shared_ptr<Context>& context
     }
     return Expr::make_symbol(expr->as_string());
 }
+
+
+shared_ptr<Expr> primitives::eq_string(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    if (args->empty() || args->cdr()->is_nil())
+    {
+        throw GlomError("Invalid number of arguments string=?: at least two arguments required");
+    }
+    const auto first_expr = eval(context, std::move(args->car()));
+    if (!first_expr->is_string())
+    {
+        throw GlomError("Invalid argument string=?: " + first_expr->to_string() + " is not a string");
+    }
+    const auto rest = args->cdr()->as_pair();
+    const auto& first = first_expr;
+    for (const auto it: *rest)
+    {
+        if (!it) break;
+        const auto next_expr = eval(context, it);
+        if (!next_expr->is_string())
+        {
+            throw GlomError("Invalid argument string=?: " + next_expr->to_string() + " is not a string");
+        }
+        if (first->as_string() != next_expr->as_string())
+        {
+            return Expr::FALSE;
+        }
+    }
+    return Expr::TRUE;
+}
+
+shared_ptr<Expr> primitives::eq_string_ignore_case(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    if (args->empty() || args->cdr()->is_nil())
+    {
+        throw GlomError("Invalid number of arguments string-ci=?: at least two arguments required");
+    }
+    const auto first_expr = eval(context, std::move(args->car()));
+    if (!first_expr->is_string())
+    {
+        throw GlomError("Invalid argument string-ci=?: " + first_expr->to_string() + " is not a string");
+    }
+    const auto rest = args->cdr()->as_pair();
+    const auto& first = first_expr;
+    for (const auto it: *rest)
+    {
+        if (!it) break;
+        const auto next_expr = eval(context, it);
+        if (!next_expr->is_string())
+        {
+            throw GlomError("Invalid argument string-ci=?: " + next_expr->to_string() + " is not a string");
+        }
+
+        // case insensitive comparison
+        const auto& str1 = first->as_string();
+        const auto& str2 = next_expr->as_string();
+        if (str1.size() != str2.size()) return Expr::FALSE;
+        for (size_t i = 0; i < str1.size(); ++i)
+        {
+            if (tolower(str1[i]) != tolower(str2[i])) return Expr::FALSE;
+        }
+    }
+    return Expr::TRUE;
+}

--- a/src/primitives/type.cpp
+++ b/src/primitives/type.cpp
@@ -2,10 +2,13 @@
 // Created by glom on 9/27/25.
 //
 
+#include <cmath>
+
 #include "error.h"
 #include "context.h"
 #include "expr.h"
 #include "primitive.h"
+#include "tokenizer.h"
 
 shared_ptr<Expr> primitives::is_pair(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
 {
@@ -22,3 +25,171 @@ shared_ptr<Expr> primitives::is_number(const shared_ptr<Context>& context, share
     return Expr::make_boolean(expr->is_number());
 }
 
+// is_boolean
+shared_ptr<Expr> primitives::is_boolean(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> expr = nullptr;
+    primitives_utils::expect_1_arg("boolean?", args, expr);
+    expr = eval(context, std::move(expr));
+    return Expr::make_boolean(expr->is_boolean());
+}
+// is_symbol
+shared_ptr<Expr> primitives::is_symbol(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> expr = nullptr;
+    primitives_utils::expect_1_arg("symbol?", args, expr);
+    expr = eval(context, std::move(expr));
+    return Expr::make_boolean(expr->is_symbol());
+}
+
+// is_string
+shared_ptr<Expr> primitives::is_string(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> expr = nullptr;
+    primitives_utils::expect_1_arg("string?", args, expr);
+    expr = eval(context, std::move(expr));
+    return Expr::make_boolean(expr->is_string());
+}
+
+// is_exact
+shared_ptr<Expr> primitives::is_exact(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> expr = nullptr;
+    primitives_utils::expect_1_arg("string?", args, expr);
+    expr = eval(context, std::move(expr));
+    return Expr::make_boolean(expr->is_number() && (expr->is_number_int() || expr->is_number_rat()));
+}
+
+// is_inexact
+shared_ptr<Expr> primitives::is_inexact(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> expr = nullptr;
+    primitives_utils::expect_1_arg("inexact?", args, expr);
+    expr = eval(context, std::move(expr));
+    return Expr::make_boolean(expr->is_number_real());
+}
+
+// exact->inexact
+shared_ptr<Expr> primitives::exact_to_inexact(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> expr = nullptr;
+    primitives_utils::expect_1_arg("exact->inexact", args, expr);
+    expr = eval(context, std::move(expr));
+    if (!expr->is_number())
+    {
+        throw GlomError("Invalid argument exact->inexact: " + expr->to_string() + " is not a number");
+    }
+    if (expr->is_number_real())
+    {
+        return expr;
+    }
+    if (expr->is_number_int())
+    {
+        return Expr::make_number_real(expr->as_number_int().to_real());
+    }
+    return Expr::make_number_real(expr->as_number_rat().to_inexact());
+}
+
+shared_ptr<Expr> primitives::inexact_to_exact(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> expr = nullptr;
+    primitives_utils::expect_1_arg("inexact->exact", args, expr);
+    expr = eval(context, std::move(expr));
+    if (!expr->is_number())
+    {
+        throw GlomError("Invalid argument inexact->exact: " + expr->to_string() + " is not a number");
+    }
+    if (expr->is_number_int())
+    {
+        return Expr::make_number_real(expr->as_number_int().to_real());
+    }
+    if (expr->is_number_rat())
+    {
+        return Expr::make_number_real(expr->as_number_rat().to_inexact());
+    }
+    const auto real = expr->as_number_real();
+    if (std::trunc(real) == real)
+    {
+        return Expr::make_number_int(integer(static_cast<int64_t>(real)));
+    }
+    return Expr::make_number_exact(rational::from_real(real));
+}
+
+// number->string
+shared_ptr<Expr> primitives::number_to_string(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> expr = nullptr;
+    primitives_utils::expect_1_arg("number->string", args, expr);
+    expr = eval(context, std::move(expr));
+    if (!expr->is_number())
+    {
+        throw GlomError("Invalid argument number->string: " + expr->to_string() + " is not a number");
+    }
+    if (expr->is_number_int())
+    {
+        return Expr::make_string(std::make_unique<string>(expr->as_number_int().to_decimal_string()));
+    }
+    if (expr->is_number_rat())
+    {
+        return Expr::make_string(std::make_unique<string>(expr->as_number_rat().to_rational_string()));
+    }
+    return Expr::make_string(std::make_unique<string>(std::to_string(expr->as_number_real())));
+}
+
+// string->number
+shared_ptr<Expr> primitives::string_to_number(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> expr = nullptr;
+    primitives_utils::expect_1_arg("string->number", args, expr);
+    expr = eval(context, std::move(expr));
+    if (!expr->is_string())
+    {
+        throw GlomError("Invalid argument string->number: " + expr->to_string() + " is not a string");
+    }
+    auto& str = expr->as_string();
+    auto tokenizer = Tokenizer(str);
+    const auto token = tokenizer.next();
+    if (const auto next = tokenizer.next(); next.get_type() != TOKEN_EOI)
+    {
+        return Expr::FALSE;
+    }
+    if (token.get_type() == TOKEN_NUMBER_INT)
+    {
+        return Expr::make_number_int(token.as_number_int());
+    }
+    if (token.get_type() == TOKEN_NUMBER_RAT)
+    {
+        return Expr::make_number_rat(token.as_number_rat());
+    }
+    if (token.get_type() == TOKEN_NUMBER_REAL)
+    {
+        return Expr::make_number_real(token.as_number_real());
+    }
+    return Expr::FALSE;
+}
+
+// symbol->string
+shared_ptr<Expr> primitives::symbol_to_string(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> expr = nullptr;
+    primitives_utils::expect_1_arg("symbol->string", args, expr);
+    expr = eval(context, std::move(expr));
+    if (!expr->is_symbol())
+    {
+        throw GlomError("Invalid argument symbol->string: " + expr->to_string() + " is not a symbol");
+    }
+    return Expr::make_string(std::make_unique<string>(expr->as_symbol()));
+}
+
+// string->symbol
+shared_ptr<Expr> primitives::string_to_symbol(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
+{
+    shared_ptr<Expr> expr = nullptr;
+    primitives_utils::expect_1_arg("string->symbol", args, expr);
+    expr = eval(context, std::move(expr));
+    if (!expr->is_string())
+    {
+        throw GlomError("Invalid argument string->symbol: " + expr->to_string() + " is not a string");
+    }
+    return Expr::make_symbol(expr->as_string());
+}

--- a/src/primitives/type.cpp
+++ b/src/primitives/type.cpp
@@ -11,14 +11,14 @@ shared_ptr<Expr> primitives::is_pair(const shared_ptr<Context>& context, shared_
 {
     shared_ptr<Expr> expr = nullptr;
     primitives_utils::expect_1_arg("pair?", args, expr);
-    expr = context->eval(std::move(expr));
+    expr = eval(context, std::move(expr));
     return Expr::make_boolean(expr->is_pair());
 }
 shared_ptr<Expr> primitives::is_number(const shared_ptr<Context>& context, shared_ptr<Pair>&& args)
 {
     shared_ptr<Expr> expr = nullptr;
     primitives_utils::expect_1_arg("number?", args, expr);
-    expr = context->eval(std::move(expr));
+    expr = eval(context, std::move(expr));
     return Expr::make_boolean(expr->is_number());
 }
 

--- a/src/primitives/util.cpp
+++ b/src/primitives/util.cpp
@@ -67,17 +67,17 @@ void primitives_utils::expect_2_args(const string& proc, const shared_ptr<Pair>&
     }
 }
 
-void primitives_utils::expect_2_or_3_args(const string& name, const shared_ptr<Pair>& args, shared_ptr<Expr>& a, shared_ptr<Expr>& b, shared_ptr<Expr>& c)
+void primitives_utils::expect_2_or_3_args(const string& proc, const shared_ptr<Pair>& args, shared_ptr<Expr>& a, shared_ptr<Expr>& b, shared_ptr<Expr>& c)
 {
     if (args->empty())
     {
-        throw GlomError(name + ": expects 2 or 3 arguments, given 0");
+        throw GlomError(proc + ": expects 2 or 3 arguments, given 0");
     }
     a = args->car();
     const auto cdr = args->cdr();
     if (cdr->is_nil())
     {
-        throw GlomError(name + ": expects 2 or 3 arguments, given 1");
+        throw GlomError(proc + ": expects 2 or 3 arguments, given 1");
     }
     const auto rest = cdr->as_pair();
     b = rest->car();
@@ -91,6 +91,25 @@ void primitives_utils::expect_2_or_3_args(const string& name, const shared_ptr<P
     c = rest2->car();
     if (!rest2->cdr()->is_nil())
     {
-        throw GlomError(name + ": expects 2 or 3 arguments, given more than 3");
+        throw GlomError(proc + ": expects 2 or 3 arguments, given more than 3");
     }
+}
+
+void primitives_utils::take_car(const string& proc, const shared_ptr<Expr>& list, const shared_ptr<Expr>& expr, shared_ptr<Expr>& car)
+{
+    if (!expr->is_pair() || expr->is_nil())
+    {
+        throw GlomError(proc + ": incorrect list structure: " + list->to_string());
+    }
+    const auto pair = expr->as_pair();
+    car = pair->car();
+}
+void primitives_utils::take_cdr(const string& proc, const shared_ptr<Expr>& list, const shared_ptr<Expr>& expr, shared_ptr<Expr>& cdr)
+{
+    if (!expr->is_pair() || expr->is_nil())
+    {
+        throw GlomError(proc + ": incorrect list structure: " + list->to_string());
+    }
+    const auto pair = expr->as_pair();
+    cdr = pair->cdr();
 }

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -164,7 +164,7 @@ Token Tokenizer::next_number()
             index++;
         }
     }
-    if (input[index] == 'e')
+    if (input[index] == 'e' || input[index] == 'E')
     {
         decimal = true;
         index++;

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -292,7 +292,15 @@ Token Tokenizer::next()
         return Token::make_end_of_input();
     }
     const char current = input[index];
-
+    if (!lang && index == 0 && current == '#')
+    {
+        lang = true;
+        while (index < input.size() && input[index] != '\n')
+        {
+            index++;
+        }
+        return next();
+    }
     if (current == ';')
     {
         // Skip comment until end of line

--- a/tests/eval_list.cpp
+++ b/tests/eval_list.cpp
@@ -1,0 +1,314 @@
+#include <gtest/gtest.h>
+#include <vector>
+#include <memory>
+
+#include "expr.h"
+#include "context.h"
+#include "parser.h"
+#include "eval.h"
+
+class SchemeListTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        context = make_root_context();
+    }
+
+    void TearDown() override
+    {
+        context.reset();
+    }
+
+    [[nodiscard]] shared_ptr<Expr> eval(const std::string& input) const
+    {
+        const auto exprs = parse(input);
+        return ::eval(context, exprs);
+    }
+
+    void perform(const std::string& input) const
+    {
+        const auto exprs = parse(input);
+        ::eval(context, exprs);
+    }
+
+    static shared_ptr<Expr> parse_and_get_first(const std::string& input)
+    {
+        const auto exprs = parse(input);
+        if (exprs->empty()) return Expr::NOTHING;
+        return exprs->car();
+    }
+
+    std::shared_ptr<Context> context;
+};
+
+// List operations tests
+TEST_F(SchemeListTest, Cons)
+{
+    const auto result = eval("(cons 1 2)");
+    EXPECT_EQ(PAIR, result->get_type());
+    const auto pair = result->as_pair();
+    EXPECT_EQ(integer(1), pair->car()->as_number_int());
+    EXPECT_EQ(integer(2), pair->cdr()->as_number_int());
+
+    // Test building lists
+    const auto list = eval("(cons 1 (cons 2 '()))");
+    EXPECT_EQ(PAIR, list->get_type());
+}
+
+TEST_F(SchemeListTest, Car)
+{
+    EXPECT_EQ(integer(1), eval("(car '(1 2 3))")->as_number_int());
+    EXPECT_EQ(integer(1), eval("(car (cons 1 2))")->as_number_int());
+}
+
+TEST_F(SchemeListTest, Cdr)
+{
+    const auto result = eval("(cdr '(1 2 3))");
+    EXPECT_EQ(PAIR, result->get_type());
+    EXPECT_EQ(integer(2), result->as_pair()->car()->as_number_int());
+
+    EXPECT_EQ(integer(2), eval("(cdr (cons 1 2))")->as_number_int());
+}
+
+TEST_F(SchemeListTest, List)
+{
+    const auto result = eval("(list 1 2 3)");
+    EXPECT_EQ(PAIR, result->get_type());
+
+    const auto pair = result->as_pair();
+    EXPECT_EQ(integer(1),pair->car()->as_number_int());
+
+    const auto second = pair->cdr()->as_pair();
+    EXPECT_EQ(integer(2),second->car()->as_number_int());
+
+    const auto third = second->cdr()->as_pair();
+    EXPECT_EQ(integer(3),third->car()->as_number_int());
+    EXPECT_TRUE(third->cdr()->is_nil());
+
+    // Empty list
+    EXPECT_TRUE(eval("(list)")->is_nil());
+}
+
+TEST_F(SchemeListTest, Append)
+{
+    const auto result = eval("(append '(1 2) '(3 4))");
+    EXPECT_EQ(PAIR, result->get_type());
+
+    auto pair = result->as_pair();
+    EXPECT_EQ(integer(1),pair->car()->as_number_int());
+
+    pair = pair->cdr()->as_pair();
+    EXPECT_EQ(integer(2),pair->car()->as_number_int());
+
+    pair = pair->cdr()->as_pair();
+    EXPECT_EQ(integer(3),pair->car()->as_number_int());
+
+    pair = pair->cdr()->as_pair();
+    EXPECT_EQ(integer(4),pair->car()->as_number_int());
+    EXPECT_TRUE(pair->cdr()->is_nil());
+
+    // Append with empty list
+    EXPECT_TRUE(eval("(append '() '(1 2))")->as_pair()->to_string() == "(1 2)");
+    EXPECT_TRUE(eval("(append '(1 2) '())")->as_pair()->to_string() == "(1 2)");
+    EXPECT_TRUE(eval("(append '() '())")->is_nil());
+}
+
+TEST_F(SchemeListTest, IsNull)
+{
+    EXPECT_EQ(Expr::TRUE, eval("(null? '())"));
+    EXPECT_EQ(Expr::FALSE, eval("(null? '(1 2 3))"));
+    EXPECT_EQ(Expr::FALSE, eval("(null? 1)"));
+    EXPECT_EQ(Expr::FALSE, eval("(null? #t)"));
+}
+
+TEST_F(SchemeListTest, CarCdrCombinations)
+{
+    // caar - (car (car x))
+    EXPECT_EQ(integer(1), eval("(caar '((1 2) 3 4))")->as_number_int());
+
+    // cadr - (car (cdr x))
+    EXPECT_EQ(integer(2), eval("(cadr '(1 2 3))")->as_number_int());
+
+    // cdar - (cdr (car x))
+    const auto cdar_result = eval("(cdar '((1 2 3) 4 5))");
+    EXPECT_EQ(PAIR, cdar_result->get_type());
+    EXPECT_EQ("(2 3)", cdar_result->to_string());
+
+    // cddr - (cdr (cdr x))
+    const auto cddr_result = eval("(cddr '(1 2 3 4))");
+    EXPECT_EQ(PAIR, cddr_result->get_type());
+    EXPECT_EQ("(3 4)", cddr_result->to_string());
+}
+
+TEST_F(SchemeListTest, ThreeLevelCombinations)
+{
+    // caaar - (car (car (car x)))
+    EXPECT_EQ(integer(1), eval("(caaar '(((1 2) 3) 4))")->as_number_int());
+
+    // caadr - (car (car (cdr x)))
+    EXPECT_EQ(integer(2), eval("(caadr '(1 (2 (3 4)) 5))")->as_number_int());
+
+    // cadar - (car (cdr (car x)))
+    EXPECT_EQ(integer(2), eval("(cadar '((1 2 3) 4))")->as_number_int());
+
+    // caddr - (car (cdr (cdr x)))
+    EXPECT_EQ(integer(3), eval("(caddr '(1 2 3 4))")->as_number_int());
+
+    // cdaar - (cdr (car (car x)))
+    const auto cdaar_result = eval("(cdaar '(((1 2 3) 4) 5))");
+    EXPECT_EQ(PAIR, cdaar_result->get_type());
+    EXPECT_EQ("(2 3)", cdaar_result->to_string());
+
+    // cdadr - (cdr (car (cdr x)))
+    const auto cdadr_result = eval("(cdadr '(1 (2 3 4) 5))");
+    EXPECT_EQ(PAIR, cdadr_result->get_type());
+    EXPECT_EQ("(3 4)", cdadr_result->to_string());
+
+    // cddar - (cdr (cdr (car x)))
+    const auto cddar_result = eval("(cddar '((1 2 3 4) 5))");
+    EXPECT_EQ(PAIR, cddar_result->get_type());
+    EXPECT_EQ("(3 4)", cddar_result->to_string());
+
+    // cdddr - (cdr (cdr (cdr x)))
+    const auto cdddr_result = eval("(cdddr '(1 2 3 4 5))");
+    EXPECT_EQ(PAIR, cdddr_result->get_type());
+    EXPECT_EQ("(4 5)", cdddr_result->to_string());
+}
+
+TEST_F(SchemeListTest, FourLevelCombinations)
+{
+    // caaaar = (car (car (car (car x))))
+    EXPECT_EQ(integer(1), eval("(caaaar '((((1 2) 3) 4) 5))")->as_number_int());
+
+    // caaadr = (car (car (car (cdr x))))
+    EXPECT_EQ(integer(4), eval("(caaadr '(5 ((4 3) 2) 1))")->as_number_int());
+
+    // caadar = (car (car (cdr (car x))))
+    EXPECT_EQ(integer(3), eval("(caadar '((2 (3) 6)))")->as_number_int());
+
+    // caaddr = (car (car (cdr (cdr x))))
+    EXPECT_EQ(integer(3), eval("(caaddr '(1 2 (3 4) 5 6))")->as_number_int());
+
+    // cadaar = (car (cdr (car (car x))))
+    EXPECT_EQ(integer(2), eval("(cadaar '(((1 2 3) 4) 5))")->as_number_int());
+
+    // cadadr = (car (cdr (car (cdr x))))
+    EXPECT_EQ(integer(3), eval("(cadadr '(1 (2 3 4) 5))")->as_number_int());
+
+    // caddar = (car (cdr (cdr (car x))))
+    EXPECT_EQ(integer(3), eval("(caddar '((1 2 3 4) 5))")->as_number_int());
+
+    // cadddr = (car (cdr (cdr (cdr x))))
+    EXPECT_EQ(integer(4), eval("(cadddr '(1 2 3 4 5))")->as_number_int());
+
+    // cdaaar = (cdr (car (car (car x))))
+    const auto cdaaar_result = eval("(cdaaar '((((1 2 3) 4) 5) 6))");
+    EXPECT_EQ(PAIR, cdaaar_result->get_type());
+    EXPECT_EQ("(2 3)", cdaaar_result->to_string());
+
+    // cdaadr = (cdr (car (car (cdr x))))
+    const auto cdaadr_result = eval("(cdaadr '(1 ((2 (3 4 5)) 6) 7))");
+    EXPECT_EQ(PAIR, cdaadr_result->get_type());
+    EXPECT_EQ("((3 4 5))", cdaadr_result->to_string());
+
+    // cdadar = (cdr (car (cdr (car x))))
+    const auto cdadar_result = eval("(cdadar '((1 (2 3 4) 5) 6))");
+    EXPECT_EQ(PAIR, cdadar_result->get_type());
+    EXPECT_EQ("(3 4)", cdadar_result->to_string());
+
+    // cdaddr = (cdr (car (cdr (cdr x))))
+    const auto cdaddr_result = eval("(cdaddr '(1 2 ((3 4) 5 6) 7))");
+    EXPECT_EQ(PAIR, cdaddr_result->get_type());
+    EXPECT_EQ("(5 6)", cdaddr_result->to_string());
+
+    // cddaar = (cdr (cdr (car (car x))))
+    const auto cddaar_result = eval("(cddaar '(((1 2 3 4) 5) 6))");
+    EXPECT_EQ(PAIR, cddaar_result->get_type());
+    EXPECT_EQ("(3 4)", cddaar_result->to_string());
+
+    // cddadr = (cdr (cdr (car (cdr x))))
+    const auto cddadr_result = eval("(cddadr '(1 (2 3 4 5) 6))");
+    EXPECT_EQ(PAIR, cddadr_result->get_type());
+    EXPECT_EQ("(4 5)", cddadr_result->to_string());
+
+    // cdddar = (cdr (cdr (cdr (car x))))
+    const auto cdddar_result = eval("(cdddar '((1 2 3 4 5) 6))");
+    EXPECT_EQ(PAIR, cdddar_result->get_type());
+    EXPECT_EQ("(4 5)", cdddar_result->to_string());
+
+    // cddddr = (cdr (cdr (cdr (cdr x))))
+    const auto cddddr_result = eval("(cddddr '(1 2 3 4 5 6))");
+    EXPECT_EQ(PAIR, cddddr_result->get_type());
+    EXPECT_EQ("(5 6)", cddddr_result->to_string());
+}
+
+
+TEST_F(SchemeListTest, CarCdrErrorCases)
+{
+    // Test error cases - operations on non-pairs
+    EXPECT_THROW(perform("(car 1)"), std::runtime_error);
+    EXPECT_THROW(perform("(cdr 1)"), std::runtime_error);
+    EXPECT_THROW(perform("(caar 1)"), std::runtime_error);
+    EXPECT_THROW(perform("(cadr 1)"), std::runtime_error);
+
+    // Test error cases - operations on empty lists
+    EXPECT_THROW(perform("(car '())"), std::runtime_error);
+    EXPECT_THROW(perform("(cdr '())"), std::runtime_error);
+    EXPECT_THROW(perform("(caar '())"), std::runtime_error);
+
+    // Test error cases - insufficient nesting
+    EXPECT_THROW(perform("(caar '(1))"), std::runtime_error);
+    EXPECT_THROW(perform("(cadr '(1))"), std::runtime_error);
+    EXPECT_THROW(perform("(caddr '(1 2))"), std::runtime_error);
+}
+
+TEST_F(SchemeListTest, AllCadrTest)
+{
+    // Level 1
+    EXPECT_EQ("car", eval("(car '(car . cdr))")->to_string());
+    EXPECT_EQ("cdr", eval("(cdr '(car . cdr))")->to_string());
+
+    // Level 2
+    EXPECT_EQ("caar", eval("(caar '((caar . cadr) . (cdar . cddr)))")->to_string());
+    EXPECT_EQ("cadr", eval("(cadr '((caar . cdar) . (cadr . cddr)))")->to_string());
+    EXPECT_EQ("cdar", eval("(cdar '((caar . cdar) . (cadr . cddr)))")->to_string());
+    EXPECT_EQ("cddr", eval("(cddr '((caar . cdar) . (cadr . cddr)))")->to_string());
+
+    // Level 3
+    perform("(define list3 '(((caaar . cdaar) . (cadar . cddar)) . ((caadr . cdadr) . (caddr . cdddr))))");
+
+    EXPECT_EQ("caaar", eval("(caaar list3)")->to_string());
+    EXPECT_EQ("caadr", eval("(caadr list3)")->to_string());
+    EXPECT_EQ("cadar", eval("(cadar list3)")->to_string());
+    EXPECT_EQ("caddr", eval("(caddr list3)")->to_string());
+
+    EXPECT_EQ("cdaar", eval("(cdaar list3)")->to_string());
+    EXPECT_EQ("cdadr", eval("(cdadr list3)")->to_string());
+    EXPECT_EQ("cddar", eval("(cddar list3)")->to_string());
+    EXPECT_EQ("cdddr", eval("(cdddr list3)")->to_string());
+
+    // Level 4
+    perform(R"((define list4 '(
+                (( (caaaar . cdaaar) . (cadaar . cddaar) ) . ( (caadar . cdadar) . (caddar . cdddar) )) .
+                (( (cdaaar . cdaadr) . (cadadr . cddadr) ) . ( (caaddr . cdaddr) . (cadddr . cddddr) ))
+)
+))");
+
+    EXPECT_EQ("caaaar", eval("(caaaar list4)")->to_string());
+    EXPECT_EQ("cdaaar", eval("(cdaaar list4)")->to_string());
+    EXPECT_EQ("caadar", eval("(caadar list4)")->to_string());
+    EXPECT_EQ("caaddr", eval("(caaddr list4)")->to_string());
+    EXPECT_EQ("cadaar", eval("(cadaar list4)")->to_string());
+    EXPECT_EQ("cadadr", eval("(cadadr list4)")->to_string());
+    EXPECT_EQ("caddar", eval("(caddar list4)")->to_string());
+    EXPECT_EQ("cadddr", eval("(cadddr list4)")->to_string());
+    EXPECT_EQ("cdaaar", eval("(cdaaar list4)")->to_string());
+    EXPECT_EQ("cdaadr", eval("(cdaadr list4)")->to_string());
+    EXPECT_EQ("cdadar", eval("(cdadar list4)")->to_string());
+    EXPECT_EQ("cdaddr", eval("(cdaddr list4)")->to_string());
+    EXPECT_EQ("cddaar", eval("(cddaar list4)")->to_string());
+    EXPECT_EQ("cddadr", eval("(cddadr list4)")->to_string());
+    EXPECT_EQ("cdddar", eval("(cdddar list4)")->to_string());
+    EXPECT_EQ("cddddr", eval("(cddddr list4)")->to_string());
+}

--- a/tests/eval_math_functions.cpp
+++ b/tests/eval_math_functions.cpp
@@ -1,0 +1,145 @@
+//
+// Created by glom on 10/1/25.
+//
+#include <gtest/gtest.h>
+#include <vector>
+#include <memory>
+
+#include "expr.h"
+#include "context.h"
+#include "parser.h"
+#include "eval.h"
+
+class SchemeMathTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        context = make_root_context();
+    }
+
+    void TearDown() override
+    {
+        context.reset();
+    }
+
+    [[nodiscard]] shared_ptr<Expr> eval(const std::string& input) const
+    {
+        const auto exprs = parse(input);
+        return ::eval(context, exprs);
+    }
+
+    void perform(const std::string& input) const
+    {
+        const auto exprs = parse(input);
+        ::eval(context, exprs);
+    }
+
+    static shared_ptr<Expr> parse_and_get_first(const std::string& input)
+    {
+        const auto exprs = parse(input);
+        if (exprs->empty()) return Expr::NOTHING;
+        return exprs->car();
+    }
+
+    std::shared_ptr<Context> context;
+};
+
+
+// sqrt function tests
+TEST_F(SchemeMathTest, SquareRoot)
+{
+    EXPECT_EQ(integer(2), eval("(sqrt 4)")->as_number_int());
+    EXPECT_NEAR(1.414, eval("(sqrt 2)")->as_number_real(), 0.001);
+    EXPECT_EQ(integer(3), eval("(sqrt 9)")->as_number_int());
+    EXPECT_EQ(integer(0), eval("(sqrt 0)")->as_number_int());
+    EXPECT_NEAR(1.732, eval("(sqrt 3)")->as_number_real(), 0.001);
+}
+
+// isqrt function tests (integer square root)
+TEST_F(SchemeMathTest, IntegerSquareRoot)
+{
+    EXPECT_EQ(integer(2), eval("(isqrt 4)")->as_number_int());
+    EXPECT_EQ(integer(1), eval("(isqrt 2)")->as_number_int());
+    EXPECT_EQ(integer(3), eval("(isqrt 9)")->as_number_int());
+    EXPECT_EQ(integer(0), eval("(isqrt 0)")->as_number_int());
+    EXPECT_EQ(integer(1), eval("(isqrt 3)")->as_number_int());
+    EXPECT_EQ(integer(10), eval("(isqrt 100)")->as_number_int());
+    EXPECT_EQ(integer(10), eval("(isqrt 110)")->as_number_int());
+}
+
+// log function tests (natural logarithm)
+TEST_F(SchemeMathTest, Logarithm)
+{
+    EXPECT_EQ(integer(0), eval("(log 1)")->as_number_int());
+    EXPECT_NEAR(1.0, eval("(log 2.71828)")->as_number_real(), 0.001);
+    EXPECT_NEAR(2.302, eval("(log 10)")->as_number_real(), 0.001);
+    EXPECT_NEAR(0.693, eval("(log 2)")->as_number_real(), 0.001);
+}
+
+// sin function tests
+TEST_F(SchemeMathTest, Sine)
+{
+    EXPECT_EQ(integer(0), eval("(sin 0)")->as_number_int());
+    EXPECT_NEAR(1.0, eval("(sin 1.5708)")->as_number_real(), 0.001); // π/2
+    EXPECT_NEAR(0.0, eval("(sin 3.14159)")->as_number_real(), 0.001); // π
+    EXPECT_NEAR(-1.0, eval("(sin 4.71239)")->as_number_real(), 0.001); // 3π/2
+    EXPECT_NEAR(0.5, eval("(sin 0.523599)")->as_number_real(), 0.001); // π/6
+}
+
+// cos function tests
+TEST_F(SchemeMathTest, Cosine)
+{
+    EXPECT_EQ(integer(1), eval("(cos 0)")->as_number_int());
+    EXPECT_NEAR(0.0, eval("(cos 1.5708)")->as_number_real(), 0.001); // π/2
+    EXPECT_NEAR(-1.0, eval("(cos 3.14159)")->as_number_real(), 0.001); // π
+    EXPECT_NEAR(0.0, eval("(cos 4.71239)")->as_number_real(), 0.001); // 3π/2
+    EXPECT_NEAR(0.866, eval("(cos 0.523599)")->as_number_real(), 0.001); // π/6
+}
+
+// tan function tests
+TEST_F(SchemeMathTest, Tangent)
+{
+    EXPECT_EQ(integer(0), eval("(tan 0)")->as_number_int());
+    EXPECT_NEAR(1.0, eval("(tan 0.785398)")->as_number_real(), 0.001); // π/4
+    EXPECT_NEAR(0.577, eval("(tan 0.523599)")->as_number_real(), 0.001); // π/6
+    EXPECT_NEAR(1.732, eval("(tan 1.0472)")->as_number_real(), 0.001); // π/3
+}
+
+// asin function tests (arcsine)
+TEST_F(SchemeMathTest, ArcSine)
+{
+    EXPECT_EQ(integer(0), eval("(asin 0)")->as_number_int());
+    EXPECT_NEAR(1.5708, eval("(asin 1)")->as_number_real(), 0.001); // π/2
+    EXPECT_NEAR(-1.5708, eval("(asin -1)")->as_number_real(), 0.001); // -π/2
+    EXPECT_NEAR(0.523599, eval("(asin 0.5)")->as_number_real(), 0.001); // π/6
+}
+
+// acos function tests (arccosine)
+TEST_F(SchemeMathTest, ArcCosine)
+{
+    EXPECT_NEAR(1.5708, eval("(acos 0)")->as_number_real(), 0.001); // π/2
+    EXPECT_EQ(integer(0), eval("(acos 1)")->as_number_int());
+    EXPECT_NEAR(3.14159, eval("(acos -1)")->as_number_real(), 0.001); // π
+    EXPECT_NEAR(1.0472, eval("(acos 0.5)")->as_number_real(), 0.001); // π/3
+}
+
+// atan function tests (arctangent)
+TEST_F(SchemeMathTest, ArcTangent)
+{
+    EXPECT_EQ(integer(0), eval("(atan 0)")->as_number_int());
+    EXPECT_NEAR(0.785398, eval("(atan 1)")->as_number_real(), 0.001); // π/4
+    EXPECT_NEAR(-0.785398, eval("(atan -1)")->as_number_real(), 0.001); // -π/4
+    EXPECT_NEAR(0.463648, eval("(atan 0.5)")->as_number_real(), 0.001); // ~26.565°
+}
+
+// exp function tests (exponential)
+TEST_F(SchemeMathTest, Exponential)
+{
+    EXPECT_EQ(integer(0), eval("(exp 0)")->as_number_int());
+    EXPECT_NEAR(2.71828, eval("(exp 1)")->as_number_real(), 0.001); // e
+    EXPECT_NEAR(7.38906, eval("(exp 2)")->as_number_real(), 0.001); // e^2
+    EXPECT_NEAR(0.367879, eval("(exp -1)")->as_number_real(), 0.001); // 1/e
+    EXPECT_NEAR(0.135335, eval("(exp -2)")->as_number_real(), 0.001); // 1/e^2
+}
+

--- a/tests/eval_number_comparators.cpp
+++ b/tests/eval_number_comparators.cpp
@@ -8,6 +8,7 @@
 #include "expr.h"
 #include "context.h"
 #include "parser.h"
+#include "eval.h"
 
 class SchemeNumComparatorsTest : public ::testing::Test
 {
@@ -25,20 +26,20 @@ protected:
     [[nodiscard]] shared_ptr<Expr> eval(const std::string& input) const
     {
         const auto exprs = parse(input);
-        return context->eval(exprs);
+        return ::eval(context, exprs);
     }
 
     void perform(const std::string& input) const
     {
         const auto exprs = parse(input);
-        context->eval(exprs);
+        ::eval(context, exprs);
     }
 
     static shared_ptr<Expr> parse_and_get_first(const std::string& input)
     {
-        auto exprs = parse(input);
-        if (exprs.empty()) return Expr::NOTHING;
-        return exprs[0];
+        const auto exprs = parse(input);
+        if (exprs->empty()) return Expr::NOTHING;
+        return exprs->car();
     }
 
     std::shared_ptr<Context> context;

--- a/tests/eval_number_operations.cpp
+++ b/tests/eval_number_operations.cpp
@@ -8,6 +8,7 @@
 #include "expr.h"
 #include "context.h"
 #include "parser.h"
+#include "eval.h"
 
 class SchemeNumOperationsTest : public ::testing::Test
 {
@@ -25,20 +26,20 @@ protected:
     [[nodiscard]] shared_ptr<Expr> eval(const std::string& input) const
     {
         const auto exprs = parse(input);
-        return context->eval(exprs);
+        return ::eval(context, exprs);
     }
 
     void perform(const std::string& input) const
     {
         const auto exprs = parse(input);
-        context->eval(exprs);
+        ::eval(context, exprs);
     }
 
     static shared_ptr<Expr> parse_and_get_first(const std::string& input)
     {
-        auto exprs = parse(input);
-        if (exprs.empty()) return Expr::NOTHING;
-        return exprs[0];
+        const auto exprs = parse(input);
+        if (exprs->empty()) return Expr::NOTHING;
+        return exprs->car();
     }
 
     std::shared_ptr<Context> context;

--- a/tests/eval_number_operations.cpp
+++ b/tests/eval_number_operations.cpp
@@ -100,6 +100,17 @@ TEST_F(SchemeNumOperationsTest, IntegerExponentiation)
     EXPECT_EQ(integer(0), eval("(expt 0 5)")->as_number_int());
 }
 
+TEST_F(SchemeNumOperationsTest, IntegerQuotient)
+{
+    // Integer Quotient
+    EXPECT_EQ(integer(2), eval("(quotient 10 5)")->as_number_int());
+    EXPECT_EQ(integer(0), eval("(quotient 5 10)")->as_number_int());
+    EXPECT_EQ(integer(-2), eval("(quotient -10 5)")->as_number_int());
+    EXPECT_EQ(integer(-2), eval("(quotient 10 -5)")->as_number_int());
+    EXPECT_EQ(integer(2), eval("(quotient -10 -5)")->as_number_int());
+    EXPECT_EQ(integer(4), eval("(quotient 20 5)")->as_number_int());
+}
+
 TEST_F(SchemeNumOperationsTest, IntegerRemainder)
 {
     // Integer remainder operation

--- a/tests/eval_number_utils.cpp
+++ b/tests/eval_number_utils.cpp
@@ -1,0 +1,213 @@
+//
+// Created by glom on 10/1/25.
+//
+#include <gtest/gtest.h>
+#include <vector>
+#include <memory>
+
+#include "expr.h"
+#include "context.h"
+#include "parser.h"
+#include "eval.h"
+
+class SchemeNumUtilsTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        context = make_root_context();
+    }
+
+    void TearDown() override
+    {
+        context.reset();
+    }
+
+    [[nodiscard]] shared_ptr<Expr> eval(const std::string& input) const
+    {
+        const auto exprs = parse(input);
+        return ::eval(context, exprs);
+    }
+
+    void perform(const std::string& input) const
+    {
+        const auto exprs = parse(input);
+        ::eval(context, exprs);
+    }
+
+    static shared_ptr<Expr> parse_and_get_first(const std::string& input)
+    {
+        const auto exprs = parse(input);
+        if (exprs->empty()) return Expr::NOTHING;
+        return exprs->car();
+    }
+
+    std::shared_ptr<Context> context;
+};
+
+
+// zero? predicate tests
+TEST_F(SchemeNumUtilsTest, IsZero)
+{
+    EXPECT_EQ(Expr::TRUE, eval("(zero? 0)"));
+    EXPECT_EQ(Expr::TRUE, eval("(zero? 0.0)"));
+    EXPECT_EQ(Expr::FALSE, eval("(zero? 1)"));
+    EXPECT_EQ(Expr::FALSE, eval("(zero? -1)"));
+    EXPECT_EQ(Expr::FALSE, eval("(zero? 0.1)"));
+}
+
+// positive? predicate tests
+TEST_F(SchemeNumUtilsTest, IsPositive)
+{
+    EXPECT_EQ(Expr::TRUE, eval("(positive? 1)"));
+    EXPECT_EQ(Expr::TRUE, eval("(positive? 1.5)"));
+    EXPECT_EQ(Expr::TRUE, eval("(positive? 0.1)"));
+    EXPECT_EQ(Expr::FALSE, eval("(positive? 0)"));
+    EXPECT_EQ(Expr::FALSE, eval("(positive? -1)"));
+    EXPECT_EQ(Expr::FALSE, eval("(positive? -1.5)"));
+}
+
+// negative? predicate tests
+TEST_F(SchemeNumUtilsTest, IsNegative)
+{
+    EXPECT_EQ(Expr::TRUE, eval("(negative? -1)"));
+    EXPECT_EQ(Expr::TRUE, eval("(negative? -1.5)"));
+    EXPECT_EQ(Expr::TRUE, eval("(negative? -0.1)"));
+    EXPECT_EQ(Expr::FALSE, eval("(negative? 0)"));
+    EXPECT_EQ(Expr::FALSE, eval("(negative? 1)"));
+    EXPECT_EQ(Expr::FALSE, eval("(negative? 1.5)"));
+}
+
+// even? predicate tests
+TEST_F(SchemeNumUtilsTest, IsEven)
+{
+    EXPECT_EQ(Expr::TRUE, eval("(even? 0)"));
+    EXPECT_EQ(Expr::TRUE, eval("(even? 2)"));
+    EXPECT_EQ(Expr::TRUE, eval("(even? -2)"));
+    EXPECT_EQ(Expr::TRUE, eval("(even? 4)"));
+    EXPECT_EQ(Expr::FALSE, eval("(even? 1)"));
+    EXPECT_EQ(Expr::FALSE, eval("(even? -1)"));
+    EXPECT_EQ(Expr::FALSE, eval("(even? 3)"));
+}
+
+// odd? predicate tests
+TEST_F(SchemeNumUtilsTest, IsOdd)
+{
+    EXPECT_EQ(Expr::TRUE, eval("(odd? 1)"));
+    EXPECT_EQ(Expr::TRUE, eval("(odd? -1)"));
+    EXPECT_EQ(Expr::TRUE, eval("(odd? 3)"));
+    EXPECT_EQ(Expr::TRUE, eval("(odd? -3)"));
+    EXPECT_EQ(Expr::FALSE, eval("(odd? 0)"));
+    EXPECT_EQ(Expr::FALSE, eval("(odd? 2)"));
+    EXPECT_EQ(Expr::FALSE, eval("(odd? -2)"));
+}
+
+// max function tests
+TEST_F(SchemeNumUtilsTest, Max)
+{
+    EXPECT_EQ(integer(3), eval("(max 1 2 3)")->as_number_int());
+    EXPECT_EQ(integer(5), eval("(max 5 2 1)")->as_number_int());
+    EXPECT_EQ(3.5, eval("(max 1.5 3.5 2.0)")->as_number_real());
+    EXPECT_EQ(integer(0), eval("(max -1 -2 0)")->as_number_int());
+    EXPECT_EQ(integer(-1), eval("(max -1 -2 -3)")->as_number_int());
+    EXPECT_EQ(integer(10), eval("(max 10)")->as_number_int());
+    EXPECT_EQ(integer(3), eval("(max 3 3)")->as_number_int());
+}
+
+// min function tests
+TEST_F(SchemeNumUtilsTest, Min)
+{
+    EXPECT_EQ(integer(1), eval("(min 1 2 3)")->as_number_int());
+    EXPECT_EQ(integer(1), eval("(min 5 2 1)")->as_number_int());
+    EXPECT_EQ(1.5, eval("(min 1.5 3.5 2.0)")->as_number_real());
+    EXPECT_EQ(integer(-2), eval("(min -1 -2 0)")->as_number_int());
+    EXPECT_EQ(integer(-3), eval("(min -1 -2 -3)")->as_number_int());
+    EXPECT_EQ(integer(10), eval("(min 10)")->as_number_int());
+    EXPECT_EQ(integer(3), eval("(min 3 3)")->as_number_int());
+}
+
+// abs function tests
+TEST_F(SchemeNumUtilsTest, Abs)
+{
+    EXPECT_EQ(integer(5), eval("(abs 5)")->as_number_int());
+    EXPECT_EQ(integer(5), eval("(abs -5)")->as_number_int());
+    EXPECT_EQ(integer(0), eval("(abs 0)")->as_number_int());
+    EXPECT_DOUBLE_EQ(3.14, eval("(abs 3.14)")->as_number_real());
+    EXPECT_DOUBLE_EQ(3.14, eval("(abs -3.14)")->as_number_real());
+    EXPECT_DOUBLE_EQ(2.5, eval("(abs 2.5)")->as_number_real());
+}
+
+// gcd function tests
+TEST_F(SchemeNumUtilsTest, Gcd)
+{
+    EXPECT_EQ(integer(2), eval("(gcd 4 6)")->as_number_int());
+    EXPECT_EQ(integer(1), eval("(gcd 3 5)")->as_number_int());
+    EXPECT_EQ(integer(5), eval("(gcd 5 0)")->as_number_int());
+    EXPECT_EQ(integer(5), eval("(gcd 0 5)")->as_number_int());
+    EXPECT_EQ(integer(0), eval("(gcd 0 0)")->as_number_int());
+    EXPECT_EQ(integer(1), eval("(gcd 1 1)")->as_number_int());
+    EXPECT_EQ(integer(6), eval("(gcd 12 18 24)")->as_number_int());
+    EXPECT_EQ(integer(2), eval("(gcd 2)")->as_number_int());
+}
+
+// lcm function tests
+TEST_F(SchemeNumUtilsTest, Lcm)
+{
+    EXPECT_EQ(integer(12), eval("(lcm 4 6)")->as_number_int());
+    EXPECT_EQ(integer(15), eval("(lcm 3 5)")->as_number_int());
+    EXPECT_EQ(integer(0), eval("(lcm 5 0)")->as_number_int());
+    EXPECT_EQ(integer(0), eval("(lcm 0 5)")->as_number_int());
+    EXPECT_EQ(integer(0), eval("(lcm 0 0)")->as_number_int());
+    EXPECT_EQ(integer(1), eval("(lcm 1 1)")->as_number_int());
+    EXPECT_EQ(integer(72), eval("(lcm 12 18 24)")->as_number_int());
+    EXPECT_EQ(integer(2), eval("(lcm 2)")->as_number_int());
+}
+
+// floor function tests
+TEST_F(SchemeNumUtilsTest, Floor)
+{
+    EXPECT_DOUBLE_EQ(3.0, eval("(floor 3.7)")->as_number_real());
+    EXPECT_DOUBLE_EQ(3.0, eval("(floor 3.2)")->as_number_real());
+    EXPECT_DOUBLE_EQ(3.0, eval("(floor 3.0)")->as_number_real());
+    EXPECT_DOUBLE_EQ(-4.0, eval("(floor -3.7)")->as_number_real());
+    EXPECT_DOUBLE_EQ(-4.0, eval("(floor -3.2)")->as_number_real());
+    EXPECT_DOUBLE_EQ(0.0, eval("(floor 0.5)")->as_number_real());
+    EXPECT_DOUBLE_EQ(-1.0, eval("(floor -0.5)")->as_number_real());
+}
+
+// ceiling function tests
+TEST_F(SchemeNumUtilsTest, Ceiling)
+{
+    EXPECT_DOUBLE_EQ(4.0, eval("(ceiling 3.7)")->as_number_real());
+    EXPECT_DOUBLE_EQ(4.0, eval("(ceiling 3.2)")->as_number_real());
+    EXPECT_DOUBLE_EQ(3.0, eval("(ceiling 3.0)")->as_number_real());
+    EXPECT_DOUBLE_EQ(-3.0, eval("(ceiling -3.7)")->as_number_real());
+    EXPECT_DOUBLE_EQ(-3.0, eval("(ceiling -3.2)")->as_number_real());
+    EXPECT_DOUBLE_EQ(1.0, eval("(ceiling 0.5)")->as_number_real());
+    EXPECT_DOUBLE_EQ(0.0, eval("(ceiling -0.5)")->as_number_real());
+}
+
+// truncate function tests
+TEST_F(SchemeNumUtilsTest, Truncate)
+{
+    EXPECT_DOUBLE_EQ(3.0, eval("(truncate 3.7)")->as_number_real());
+    EXPECT_DOUBLE_EQ(3.0, eval("(truncate 3.2)")->as_number_real());
+    EXPECT_DOUBLE_EQ(3.0, eval("(truncate 3.0)")->as_number_real());
+    EXPECT_DOUBLE_EQ(-3.0, eval("(truncate -3.7)")->as_number_real());
+    EXPECT_DOUBLE_EQ(-3.0, eval("(truncate -3.2)")->as_number_real());
+    EXPECT_DOUBLE_EQ(0.0, eval("(truncate 0.5)")->as_number_real());
+    EXPECT_DOUBLE_EQ(0.0, eval("(truncate -0.5)")->as_number_real());
+}
+
+// round function tests
+TEST_F(SchemeNumUtilsTest, Round)
+{
+    EXPECT_DOUBLE_EQ(4.0, eval("(round 3.7)")->as_number_real());
+    EXPECT_DOUBLE_EQ(3.0, eval("(round 3.2)")->as_number_real());
+    EXPECT_DOUBLE_EQ(3.0, eval("(round 3.0)")->as_number_real());
+    EXPECT_DOUBLE_EQ(4.0, eval("(round 3.5)")->as_number_real());
+    EXPECT_DOUBLE_EQ(-4.0, eval("(round -3.7)")->as_number_real());
+    EXPECT_DOUBLE_EQ(-3.0, eval("(round -3.2)")->as_number_real());
+    EXPECT_DOUBLE_EQ(1.0, eval("(round 0.5)")->as_number_real());
+    EXPECT_DOUBLE_EQ(-1.0, eval("(round -0.5)")->as_number_real());
+}

--- a/tests/eval_primitives.cpp
+++ b/tests/eval_primitives.cpp
@@ -5,6 +5,7 @@
 #include "expr.h"
 #include "context.h"
 #include "parser.h"
+#include "eval.h"
 
 class SchemePrimitivesTest : public ::testing::Test
 {
@@ -22,20 +23,20 @@ protected:
     [[nodiscard]] shared_ptr<Expr> eval(const std::string& input) const
     {
         const auto exprs = parse(input);
-        return context->eval(exprs);
+        return ::eval(context, exprs);
     }
 
     void perform(const std::string& input) const
     {
         const auto exprs = parse(input);
-        context->eval(exprs);
+        ::eval(context, exprs);
     }
 
     static shared_ptr<Expr> parse_and_get_first(const std::string& input)
     {
-        auto exprs = parse(input);
-        if (exprs.empty()) return Expr::NOTHING;
-        return exprs[0];
+        const auto exprs = parse(input);
+        if (exprs->empty()) return Expr::NOTHING;
+        return exprs->car();
     }
 
     std::shared_ptr<Context> context;

--- a/tests/eval_primitives.cpp
+++ b/tests/eval_primitives.cpp
@@ -222,61 +222,6 @@ TEST_F(SchemePrimitivesTest, Apply)
     EXPECT_EQ(NUMBER_INT, result->get_type());
     EXPECT_EQ(integer(10), result->as_number_int());
 }
-// List operations tests
-TEST_F(SchemePrimitivesTest, Cons)
-{
-    const auto result = eval("(cons 1 2)");
-    EXPECT_EQ(PAIR, result->get_type());
-    const auto pair = result->as_pair();
-    EXPECT_EQ(integer(1), pair->car()->as_number_int());
-    EXPECT_EQ(integer(2), pair->cdr()->as_number_int());
-
-    // Test building lists
-    const auto list = eval("(cons 1 (cons 2 '()))");
-    EXPECT_EQ(PAIR, list->get_type());
-}
-
-TEST_F(SchemePrimitivesTest, Car)
-{
-    EXPECT_EQ(integer(1), eval("(car '(1 2 3))")->as_number_int());
-    EXPECT_EQ(integer(1), eval("(car (cons 1 2))")->as_number_int());
-}
-
-TEST_F(SchemePrimitivesTest, Cdr)
-{
-    const auto result = eval("(cdr '(1 2 3))");
-    EXPECT_EQ(PAIR, result->get_type());
-    EXPECT_EQ(integer(2), result->as_pair()->car()->as_number_int());
-
-    EXPECT_EQ(integer(2), eval("(cdr (cons 1 2))")->as_number_int());
-}
-
-TEST_F(SchemePrimitivesTest, List)
-{
-    const auto result = eval("(list 1 2 3)");
-    EXPECT_EQ(PAIR, result->get_type());
-
-    const auto pair = result->as_pair();
-    EXPECT_EQ(integer(1),pair->car()->as_number_int());
-
-    const auto second = pair->cdr()->as_pair();
-    EXPECT_EQ(integer(2),second->car()->as_number_int());
-
-    const auto third = second->cdr()->as_pair();
-    EXPECT_EQ(integer(3),third->car()->as_number_int());
-    EXPECT_TRUE(third->cdr()->is_nil());
-
-    // Empty list
-    EXPECT_TRUE(eval("(list)")->is_nil());
-}
-
-TEST_F(SchemePrimitivesTest, IsNull)
-{
-    EXPECT_EQ(Expr::TRUE, eval("(null? '())"));
-    EXPECT_EQ(Expr::FALSE, eval("(null? '(1 2 3))"));
-    EXPECT_EQ(Expr::FALSE, eval("(null? 1)"));
-    EXPECT_EQ(Expr::FALSE, eval("(null? #t)"));
-}
 
 // Complex integration tests
 TEST_F(SchemePrimitivesTest, Factorial)

--- a/tests/eval_primitives.cpp
+++ b/tests/eval_primitives.cpp
@@ -77,6 +77,9 @@ TEST_F(SchemePrimitivesTest, LambdaApplication)
 
     perform("(define add (lambda (x y) (+ x y)))");
     EXPECT_EQ(integer(7),eval("(add 3 4)")->as_number_int());
+
+    perform("(define varargs (lambda (x . list) (+ x (apply + list))))");
+    EXPECT_EQ(integer(12),eval("(varargs 3 4 5)")->as_number_int());
 }
 
 // Binding tests

--- a/tests/eval_primitives.cpp
+++ b/tests/eval_primitives.cpp
@@ -116,6 +116,18 @@ TEST_F(SchemePrimitivesTest, Let)
     EXPECT_ANY_THROW(perform("z"));
 }
 
+// let*
+TEST_F(SchemePrimitivesTest, LetStar)
+{
+    // Let* should create sequential local bindings
+    EXPECT_EQ(integer(9),eval("(let* ((x 2) (y (+ x 5))) (+ x y))")->as_number_int());
+    EXPECT_EQ(integer(65),eval("(let* ((x 5) (y (* x 12))) (+ x y))")->as_number_int());
+
+    // Let* should not leak bindings
+    perform("(let* ((z 200)) z)");
+    EXPECT_ANY_THROW(perform("z"));
+}
+
 
 // Logic operations tests
 TEST_F(SchemePrimitivesTest, LogicalAnd)

--- a/tests/eval_types.cpp
+++ b/tests/eval_types.cpp
@@ -184,4 +184,17 @@ TEST_F(SchemeTypesTest, StringToNumber)
     EXPECT_EQ(Expr::FALSE, eval("(string->number \"12a3\")"));
 }
 
+// symbol->string
+TEST_F(SchemeTypesTest, SymbolToString)
+{
+    EXPECT_EQ("hello", eval("(symbol->string 'hello)")->as_string());
+    EXPECT_EQ("+", eval("(symbol->string '+)")->as_string());
+    EXPECT_EQ("a-b_c", eval("(symbol->string 'a-b_c)")->as_string());
+}
 
+// string->symbol
+TEST_F(SchemeTypesTest, StringToSymbol)
+{
+    EXPECT_EQ("hello", eval("(string->symbol \"hello\")->as_symbol()")->as_symbol());
+    EXPECT_EQ("+", eval("(string->symbol \"+\")->as_symbol()")->as_symbol());
+}

--- a/tests/eval_types.cpp
+++ b/tests/eval_types.cpp
@@ -1,0 +1,187 @@
+//
+// Created by glom on 10/1/25.
+//
+#include <gtest/gtest.h>
+#include <memory>
+
+#include "expr.h"
+#include "context.h"
+#include "parser.h"
+#include "eval.h"
+
+class SchemeTypesTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        context = make_root_context();
+    }
+
+    void TearDown() override
+    {
+        context.reset();
+    }
+
+    [[nodiscard]] shared_ptr<Expr> eval(const std::string& input) const
+    {
+        const auto exprs = parse(input);
+        return ::eval(context, exprs);
+    }
+
+    void perform(const std::string& input) const
+    {
+        const auto exprs = parse(input);
+        ::eval(context, exprs);
+    }
+
+    static shared_ptr<Expr> parse_and_get_first(const std::string& input)
+    {
+        const auto exprs = parse(input);
+        if (exprs->empty()) return Expr::NOTHING;
+        return exprs->car();
+    }
+
+    std::shared_ptr<Context> context;
+};
+
+
+// pair? predicate tests
+TEST_F(SchemeTypesTest, IsPair)
+{
+    EXPECT_EQ(Expr::TRUE, eval("(pair? '(1 2))"));
+    EXPECT_EQ(Expr::TRUE, eval("(pair? '(1 . 2))"));
+    EXPECT_EQ(Expr::TRUE, eval("(pair? '(a b c))"));
+    EXPECT_EQ(Expr::TRUE, eval("(pair? '())"));
+    EXPECT_EQ(Expr::FALSE, eval("(pair? 5)"));
+    EXPECT_EQ(Expr::FALSE, eval("(pair? #t)"));
+    EXPECT_EQ(Expr::FALSE, eval("(pair? \"hello\")"));
+    EXPECT_EQ(Expr::FALSE, eval("(pair? 'a)"));
+}
+
+// number? predicate tests
+TEST_F(SchemeTypesTest, IsNumber)
+{
+    EXPECT_EQ(Expr::TRUE, eval("(number? 5)"));
+    EXPECT_EQ(Expr::TRUE, eval("(number? 3.14)"));
+    EXPECT_EQ(Expr::TRUE, eval("(number? -10)"));
+    EXPECT_EQ(Expr::TRUE, eval("(number? 0)"));
+    EXPECT_EQ(Expr::TRUE, eval("(number? 2/3)"));
+    EXPECT_EQ(Expr::FALSE, eval("(number? #t)"));
+    EXPECT_EQ(Expr::FALSE, eval("(number? 'a)"));
+    EXPECT_EQ(Expr::FALSE, eval("(number? \"123\")"));
+    EXPECT_EQ(Expr::FALSE, eval("(number? '(1 2 3))"));
+}
+
+// boolean? predicate tests
+TEST_F(SchemeTypesTest, IsBoolean)
+{
+    EXPECT_EQ(Expr::TRUE, eval("(boolean? #t)"));
+    EXPECT_EQ(Expr::TRUE, eval("(boolean? #f)"));
+    EXPECT_EQ(Expr::FALSE, eval("(boolean? 0)"));
+    EXPECT_EQ(Expr::FALSE, eval("(boolean? 1)"));
+    EXPECT_EQ(Expr::FALSE, eval("(boolean? '())"));
+    EXPECT_EQ(Expr::FALSE, eval("(boolean? '(1 2))"));
+    EXPECT_EQ(Expr::FALSE, eval("(boolean? \"true\")"));
+    EXPECT_EQ(Expr::FALSE, eval("(boolean? 'a)"));
+}
+
+// symbol? predicate tests
+TEST_F(SchemeTypesTest, IsSymbol)
+{
+    EXPECT_EQ(Expr::TRUE, eval("(symbol? 'a)"));
+    EXPECT_EQ(Expr::TRUE, eval("(symbol? 'hello)"));
+    EXPECT_EQ(Expr::TRUE, eval("(symbol? '+)"));
+    EXPECT_EQ(Expr::FALSE, eval("(symbol? \"a\")"));
+    EXPECT_EQ(Expr::FALSE, eval("(symbol? 5)"));
+    EXPECT_EQ(Expr::FALSE, eval("(symbol? #t)"));
+    EXPECT_EQ(Expr::FALSE, eval("(symbol? '(a b))"));
+    EXPECT_EQ(Expr::FALSE, eval("(symbol? '())"));
+}
+
+// string? predicate tests
+TEST_F(SchemeTypesTest, IsString)
+{
+    EXPECT_EQ(Expr::TRUE, eval("(string? \"hello\")"));
+    EXPECT_EQ(Expr::TRUE, eval("(string? \"\")"));
+    EXPECT_EQ(Expr::TRUE, eval("(string? \"123\")"));
+    EXPECT_EQ(Expr::FALSE, eval("(string? 'hello)"));
+    EXPECT_EQ(Expr::FALSE, eval("(string? 123)"));
+    EXPECT_EQ(Expr::FALSE, eval("(string? #t)"));
+    EXPECT_EQ(Expr::FALSE, eval("(string? '(1 2))"));
+    EXPECT_EQ(Expr::FALSE, eval("(string? '())"));
+}
+
+// exact? predicate tests
+TEST_F(SchemeTypesTest, IsExact)
+{
+    EXPECT_EQ(Expr::TRUE, eval("(exact? 5)"));
+    EXPECT_EQ(Expr::TRUE, eval("(exact? 2/3)"));
+    EXPECT_EQ(Expr::TRUE, eval("(exact? -10)"));
+    EXPECT_EQ(Expr::FALSE, eval("(exact? 3.14)"));
+    EXPECT_EQ(Expr::FALSE, eval("(exact? 1.0)"));
+}
+
+// inexact? predicate tests
+TEST_F(SchemeTypesTest, IsInexact)
+{
+    EXPECT_EQ(Expr::TRUE, eval("(inexact? 3.14)"));
+    EXPECT_EQ(Expr::TRUE, eval("(inexact? 1.0)"));
+    EXPECT_EQ(Expr::FALSE, eval("(inexact? 5)"));
+    EXPECT_EQ(Expr::FALSE, eval("(inexact? 2/3)"));
+    EXPECT_EQ(Expr::FALSE, eval("(inexact? -10)"));
+}
+
+// exact->inexact conversion tests
+TEST_F(SchemeTypesTest, ExactToInexact)
+{
+    EXPECT_NEAR(5.0, eval("(exact->inexact 5)")->as_number_real(), 0.001);
+    EXPECT_NEAR(-10.0, eval("(exact->inexact -10)")->as_number_real(), 0.001);
+    EXPECT_NEAR(0.666, eval("(exact->inexact 2/3)")->as_number_real(), 0.001);
+    EXPECT_NEAR(3.14, eval("(exact->inexact 3.14)")->as_number_real(), 0.001); // already inexact
+}
+
+// inexact->exact conversion tests
+TEST_F(SchemeTypesTest, InexactToExact)
+{
+    EXPECT_EQ(integer(5), eval("(inexact->exact 5.0)")->as_number_int());
+    EXPECT_EQ(integer(-10), eval("(inexact->exact -10.0)")->as_number_int());
+    EXPECT_NEAR(3.14, eval("(inexact->exact 3.14)")->as_number_rat().to_inexact(), 0.001);
+    EXPECT_NEAR(3.9, eval("(inexact->exact 3.9)")->as_number_rat().to_inexact(), 0.001);
+}
+
+// number->string conversion tests
+TEST_F(SchemeTypesTest, NumberToString)
+{
+    // Test integer conversion
+    const auto result1 = eval("(number->string 123)");
+    EXPECT_TRUE(result1->is_string());
+    EXPECT_EQ("123", result1->as_string());
+
+    // Test float conversion
+    const auto result2 = eval("(number->string 3.14)");
+    EXPECT_TRUE(result2->is_string());
+
+    // Test negative number
+    const auto result3 = eval("(number->string -42)");
+    EXPECT_TRUE(result3->is_string());
+    EXPECT_EQ("-42", result3->as_string());
+}
+
+// string->number conversion tests
+TEST_F(SchemeTypesTest, StringToNumber)
+{
+    // Test integer conversion
+    EXPECT_EQ(integer(123), eval("(string->number \"123\")")->as_number_int());
+
+    // Test float conversion
+    EXPECT_NEAR(3.14, eval("(string->number \"3.14\")")->as_number_real(), 0.001);
+
+    // Test negative number
+    EXPECT_EQ(integer(-42), eval("(string->number \"-42\")")->as_number_int());
+
+    // Test invalid string
+    EXPECT_EQ(Expr::FALSE, eval("(string->number \"hello\")"));
+    EXPECT_EQ(Expr::FALSE, eval("(string->number \"12a3\")"));
+}
+
+

--- a/tests/eval_types.cpp
+++ b/tests/eval_types.cpp
@@ -195,6 +195,27 @@ TEST_F(SchemeTypesTest, SymbolToString)
 // string->symbol
 TEST_F(SchemeTypesTest, StringToSymbol)
 {
-    EXPECT_EQ("hello", eval("(string->symbol \"hello\")->as_symbol()")->as_symbol());
-    EXPECT_EQ("+", eval("(string->symbol \"+\")->as_symbol()")->as_symbol());
+    EXPECT_EQ("hello", eval("(string->symbol \"hello\")")->as_symbol());
+    EXPECT_EQ("+", eval("(string->symbol \"+\")")->as_symbol());
+}
+
+// string=?
+TEST_F(SchemeTypesTest, EqString)
+{
+    EXPECT_EQ(Expr::TRUE, eval("(string=? \"hello\" \"hello\")"));
+    EXPECT_EQ(Expr::FALSE, eval("(string=? \"hello\" \"Hello\")"));
+    EXPECT_EQ(Expr::TRUE, eval("(string=? \"\" \"\")"));
+    EXPECT_EQ(Expr::FALSE, eval("(string=? \"abc\" \"abcd\")"));
+    EXPECT_EQ(Expr::TRUE, eval("(string=? \"test\" \"test\" \"test\")"));
+    EXPECT_EQ(Expr::FALSE, eval("(string=? \"test\" \"test\" \"Test\")"));
+}
+
+// string-ci=?
+TEST_F(SchemeTypesTest, EqStringIgnoreCase)
+{
+    EXPECT_EQ(Expr::TRUE, eval("(string-ci=? \"hello\" \"Hello\")"));
+    EXPECT_EQ(Expr::TRUE, eval("(string-ci=? \"Test\" \"test\")"));
+    EXPECT_EQ(Expr::FALSE, eval("(string-ci=? \"abc\" \"abcd\")"));
+    EXPECT_EQ(Expr::TRUE, eval("(string-ci=? \"test\" \"TEST\" \"TeSt\")"));
+    EXPECT_EQ(Expr::FALSE, eval("(string-ci=? \"test\" \"test\" \"TesTt\")"));
 }

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -61,7 +61,7 @@ TEST_F(ParserTest, AtomParsing)
 
 TEST_F(ParserTest, ListParsing)
 {
-    auto exprs = parse("(1 2 3)");
+    const auto exprs = parse("(1 2 3)");
     const shared_ptr<Expr> list = std::move(exprs->car());
     EXPECT_EQ(PAIR, list->get_type());
     int index = 0;
@@ -74,7 +74,7 @@ TEST_F(ParserTest, ListParsing)
 
 TEST_F(ParserTest, QuoteParsing)
 {
-    auto exprs = parse("'(1 2 3)");
+    const auto exprs = parse("'(1 2 3)");
     const shared_ptr<Expr> list = std::move(exprs->car());
     EXPECT_EQ(PAIR, list->get_type());
     const auto& quote = list->as_pair();
@@ -88,9 +88,22 @@ TEST_F(ParserTest, QuoteParsing)
     }
 }
 
+TEST_F(ParserTest, QuotePairParsing)
+{
+    const auto exprs = parse("'((1 . 2) . (3 . 4))");
+    const shared_ptr<Expr> list = std::move(exprs->car());
+    EXPECT_EQ(PAIR, list->get_type());
+    const auto& quote = list->as_pair();
+    EXPECT_EQ("quote", quote->car()->as_symbol());
+    const auto& pair = quote->cdr()->as_pair()->car()->as_pair();
+    EXPECT_EQ("((1 . 2) 3 . 4)", pair->to_string());
+}
+
+
+
 TEST_F(ParserTest, NilParsing)
 {
-    auto exprs = parse("'()");
+    const auto exprs = parse("'()");
     const shared_ptr<Expr> quoted_nil = std::move(exprs->car());
     EXPECT_EQ(PAIR, quoted_nil->get_type());
     const auto& quote = quoted_nil->as_pair();
@@ -103,7 +116,7 @@ TEST_F(ParserTest, NilParsing)
 
 TEST_F(ParserTest, NestedList)
 {
-    auto exprs = parse("((1 2) (3 4))");
+    const auto exprs = parse("((1 2) (3 4))");
     const shared_ptr<Expr> list = std::move(exprs->car());
     EXPECT_EQ(PAIR, list->get_type());
     const auto& elements = list->as_pair();

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -17,38 +17,52 @@ protected:
 
 TEST_F(ParserTest, AtomParsing)
 {
-    const vector<shared_ptr<Expr>> exprs = parse("123 12312312312321312312312312412412412412412412412412 123/124 1748297128947981274891274.0 \"hello\" true abc");
+    auto exprs = parse("123 12312312312321312312312312412412412412412412412412 123/124 1748297128947981274891274.0 \"hello\" true abc");
+    auto current = exprs->car();
+    exprs = exprs->cdr()->as_pair();
 
-    EXPECT_EQ(7, exprs.size());
+    EXPECT_EQ(NUMBER_INT, current->get_type());
+    EXPECT_EQ(integer(123), current->as_number_int());
 
-    EXPECT_EQ(NUMBER_INT, exprs[0]->get_type());
-    EXPECT_EQ(integer(123), exprs[0]->as_number_int());
+    current = exprs->car();
+    exprs = exprs->cdr()->as_pair();
+    EXPECT_EQ(NUMBER_INT,current->get_type());
+    EXPECT_EQ(integer("12312312312321312312312312412412412412412412412412"), current->as_number_int());
 
-    EXPECT_EQ(NUMBER_INT, exprs[1]->get_type());
-    EXPECT_EQ(integer("12312312312321312312312312412412412412412412412412"), exprs[1]->as_number_int());
 
+    current = exprs->car();
+    exprs = exprs->cdr()->as_pair();
+    EXPECT_EQ(NUMBER_RAT, current->get_type());
+    EXPECT_EQ(rational(integer(123),integer(124)), current->as_number_rat());
 
-    EXPECT_EQ(NUMBER_RAT, exprs[2]->get_type());
-    EXPECT_EQ(rational(integer(123),integer(124)), exprs[2]->as_number_rat());
+    current = exprs->car();
+    exprs = exprs->cdr()->as_pair();
+    EXPECT_EQ(NUMBER_REAL, current->get_type());
+    EXPECT_EQ(from_string("1748297128947981274891274.0"), current->as_number_real());
 
-    EXPECT_EQ(NUMBER_REAL, exprs[3]->get_type());
-    EXPECT_EQ(from_string("1748297128947981274891274.0"), exprs[3]->as_number_real());
+    current = exprs->car();
+    exprs = exprs->cdr()->as_pair();
+    EXPECT_EQ(STRING, current->get_type());
+    EXPECT_EQ("hello", current->as_string());
 
-    EXPECT_EQ(STRING, exprs[4]->get_type());
-    EXPECT_EQ("hello", exprs[4]->as_string());
+    current = exprs->car();
+    exprs = exprs->cdr()->as_pair();
+    EXPECT_EQ(BOOLEAN, current->get_type());
+    EXPECT_EQ(true, current->as_boolean());
 
-    EXPECT_EQ(BOOLEAN, exprs[5]->get_type());
-    EXPECT_EQ(true, exprs[5]->as_boolean());
+    current = exprs->car();
+    exprs = exprs->cdr()->as_pair();
+    EXPECT_EQ(SYMBOL, current->get_type());
+    EXPECT_EQ("abc", current->as_symbol());
 
-    EXPECT_EQ(SYMBOL, exprs[6]->get_type());
-    EXPECT_EQ("abc", exprs[6]->as_symbol());
-
+    if (!exprs->empty())
+        FAIL() << "Expected only 7 expressions, got more.";
 }
 
 TEST_F(ParserTest, ListParsing)
 {
-    vector<shared_ptr<Expr>> exprs = parse("(1 2 3)");
-    const shared_ptr<Expr> list = std::move(exprs[0]);
+    auto exprs = parse("(1 2 3)");
+    const shared_ptr<Expr> list = std::move(exprs->car());
     EXPECT_EQ(PAIR, list->get_type());
     int index = 0;
     for (const auto elem : *list->as_pair())
@@ -60,8 +74,8 @@ TEST_F(ParserTest, ListParsing)
 
 TEST_F(ParserTest, QuoteParsing)
 {
-    vector<shared_ptr<Expr>> exprs = parse("'(1 2 3)");
-    const shared_ptr<Expr> list = std::move(exprs[0]);
+    auto exprs = parse("'(1 2 3)");
+    const shared_ptr<Expr> list = std::move(exprs->car());
     EXPECT_EQ(PAIR, list->get_type());
     const auto& quote = list->as_pair();
     EXPECT_EQ("quote", quote->car()->as_symbol());
@@ -76,8 +90,8 @@ TEST_F(ParserTest, QuoteParsing)
 
 TEST_F(ParserTest, NilParsing)
 {
-    vector<shared_ptr<Expr>> exprs = parse("'()");
-    const shared_ptr<Expr> quoted_nil = std::move(exprs[0]);
+    auto exprs = parse("'()");
+    const shared_ptr<Expr> quoted_nil = std::move(exprs->car());
     EXPECT_EQ(PAIR, quoted_nil->get_type());
     const auto& quote = quoted_nil->as_pair();
     EXPECT_EQ("quote", quote->car()->as_symbol());
@@ -89,8 +103,8 @@ TEST_F(ParserTest, NilParsing)
 
 TEST_F(ParserTest, NestedList)
 {
-    vector<shared_ptr<Expr>> exprs = parse("((1 2) (3 4))");
-    const shared_ptr<Expr> list = std::move(exprs[0]);
+    auto exprs = parse("((1 2) (3 4))");
+    const shared_ptr<Expr> list = std::move(exprs->car());
     EXPECT_EQ(PAIR, list->get_type());
     const auto& elements = list->as_pair();
     EXPECT_EQ(PAIR, elements->car()->get_type());

--- a/tests/tokenizer.cpp
+++ b/tests/tokenizer.cpp
@@ -225,6 +225,35 @@ TEST_F(TokenizerTest, ComplexExpression)
     EXPECT_EQ(actual_types, expected_types);
 }
 
+TEST_F(TokenizerTest, Comments)
+{
+    Tokenizer tokenizer(R"(
+        ; This is a comment
+        (define x 42) ; Define x
+        (define y 3.14) ; Define y
+        ; Another comment
+        (define msg "Hello, World!") ; Define msg
+    )");
+
+    const std::vector expected_types = {
+        TOKEN_LPAREN, TOKEN_SYMBOL, TOKEN_SYMBOL, TOKEN_NUMBER_INT, TOKEN_RPAREN,
+        TOKEN_LPAREN, TOKEN_SYMBOL, TOKEN_SYMBOL, TOKEN_NUMBER_REAL, TOKEN_RPAREN,
+        TOKEN_LPAREN, TOKEN_SYMBOL, TOKEN_SYMBOL, TOKEN_STRING, TOKEN_RPAREN,
+        TOKEN_EOI
+    };
+
+    std::vector<TokenType> actual_types;
+    Token current = tokenizer.next();
+    while (current.get_type() != TOKEN_EOI)
+    {
+        actual_types.push_back(current.get_type());
+        current = tokenizer.next();
+    }
+    actual_types.push_back(current.get_type());
+
+    EXPECT_EQ(actual_types, expected_types);
+}
+
 TEST_F(TokenizerTest, EndOfInput)
 {
     Tokenizer tokenizer("");


### PR DESCRIPTION
Feat:
- Tail Call Optimization
- Parse cons with dot: '(1 . 2) = (cons 1 2)
- Run file by `glom {file-path}`
Primitives:
- call/cc, error
- c[ad]{2-4}r
- quotient
- zero?, positive?, negative?
- even?, odd?
- max, min
- abs, gcd, lcm
- floor, ceiling, truncate, round
- sqrt, isqrt
- log, sin, cos, tan, asin, acos, atan
- exp
- pair?, number?, boolean?, symbol?, string?, exact?, inexact?
- exact->inexact, inexact->exact
- number->string, string->number
- symbol->string, string->symbol
- string=?, string-ic=? 
- length